### PR TITLE
Add support of presence_penalty and frequency_penalty parameter

### DIFF
--- a/src/_locales/de/main.json
+++ b/src/_locales/de/main.json
@@ -159,5 +159,7 @@
   "Gemini (Web)": "Gemini (Web)",
   "Type": "Typ",
   "Mode": "Modus",
-  "Custom": "Benutzerdefiniert"
+  "Custom": "Benutzerdefiniert",
+  "Presence Penalty": "Präsenzstrafe",
+  "Frequency Penalty": "Frequenzstrafe"
 }

--- a/src/_locales/en/main.json
+++ b/src/_locales/en/main.json
@@ -159,5 +159,7 @@
   "Gemini (Web)": "Gemini (Web)",
   "Type": "Type",
   "Mode": "Mode",
-  "Custom": "Custom"
+  "Custom": "Custom",
+  "Presence Penalty": "Presence Penalty",
+  "Frequency Penalty": "Frequency Penalty"
 }

--- a/src/_locales/es/main.json
+++ b/src/_locales/es/main.json
@@ -159,5 +159,7 @@
   "Gemini (Web)": "Gemini (Web)",
   "Type": "Tipo",
   "Mode": "Modo",
-  "Custom": "Personalizado"
+  "Custom": "Personalizado",
+  "Presence Penalty": "Penalización por presencia",
+  "Frequency Penalty": "Penalización por frecuencia"
 }

--- a/src/_locales/fr/main.json
+++ b/src/_locales/fr/main.json
@@ -159,5 +159,7 @@
   "Gemini (Web)": "Gemini (Web)",
   "Type": "Type",
   "Mode": "Mode",
-  "Custom": "Personnalisé"
+  "Custom": "Personnalisé",
+  "Presence Penalty": "Pénalité de présence",
+  "Frequency Penalty": "Pénalité de fréquence"
 }

--- a/src/_locales/in/main.json
+++ b/src/_locales/in/main.json
@@ -159,5 +159,7 @@
   "Gemini (Web)": "Gemini (Web)",
   "Type": "Jenis",
   "Mode": "Mode",
-  "Custom": "Kustom"
+  "Custom": "Kustom",
+  "Presence Penalty": "Penalti Kehadiran",
+  "Frequency Penalty": "Penalti Frekuensi"
 }

--- a/src/_locales/it/main.json
+++ b/src/_locales/it/main.json
@@ -159,5 +159,7 @@
   "Gemini (Web)": "Gemini (Web)",
   "Type": "Tipo",
   "Mode": "Modalità",
-  "Custom": "Personalizzato"
+  "Custom": "Personalizzato",
+  "Presence Penalty": "Penalità di presenza",
+  "Frequency Penalty": "Penalità di frequenza"
 }

--- a/src/_locales/ja/main.json
+++ b/src/_locales/ja/main.json
@@ -159,5 +159,7 @@
   "Gemini (Web)": "Gemini (Web)",
   "Type": "タイプ",
   "Mode": "モード",
-  "Custom": "カスタム"
+  "Custom": "カスタム",
+  "Presence Penalty": "存在ペナルティ",
+  "Frequency Penalty": "頻度ペナルティ"
 }

--- a/src/_locales/ko/main.json
+++ b/src/_locales/ko/main.json
@@ -159,5 +159,7 @@
   "Gemini (Web)": "Gemini (웹)",
   "Type": "유형",
   "Mode": "모드",
-  "Custom": "사용자 정의"
+  "Custom": "사용자 정의",
+  "Presence Penalty": "존재 패널티",
+  "Frequency Penalty": "빈도 패널티"
 }

--- a/src/_locales/pt/main.json
+++ b/src/_locales/pt/main.json
@@ -159,5 +159,7 @@
   "Gemini (Web)": "Gemini (Web)",
   "Type": "Tipo",
   "Mode": "Modo",
-  "Custom": "Personalizado"
+  "Custom": "Personalizado",
+  "Presence Penalty": "Penalidade de presença",
+  "Frequency Penalty": "Penalidade de frequência"
 }

--- a/src/_locales/ru/main.json
+++ b/src/_locales/ru/main.json
@@ -159,5 +159,7 @@
   "Gemini (Web)": "Gemini (Веб)",
   "Type": "Тип",
   "Mode": "Режим",
-  "Custom": "Пользовательский"
+  "Custom": "Пользовательский",
+  "Presence Penalty": "Штраф за присутствие",
+  "Frequency Penalty": "Штраф за частоту"
 }

--- a/src/_locales/tr/main.json
+++ b/src/_locales/tr/main.json
@@ -159,5 +159,7 @@
   "Gemini (Web)": "Gemini (Web)",
   "Type": "Tür",
   "Mode": "Mod",
-  "Custom": "Özel"
+  "Custom": "Özel",
+  "Presence Penalty": "Varlık Cezası",
+  "Frequency Penalty": "Frekans Cezası"
 }

--- a/src/_locales/zh-hans/main.json
+++ b/src/_locales/zh-hans/main.json
@@ -164,5 +164,7 @@
   "ChatGLM (GLM-4-Air, 128k)": "ChatGLM (GLM4Air, 性价比, 128k)",
   "ChatGLM (GLM-4-0520, 128k)": "ChatGLM (GLM4-0520, 最智能, 128k)",
   "ChatGLM (Emohaa)": "ChatGLM (Emohaa, 专业情绪咨询)",
-  "ChatGLM (CharGLM-3)": "ChatGLM (CharGLM-3, 角色扮演)"
+  "ChatGLM (CharGLM-3)": "ChatGLM (CharGLM-3, 角色扮演)",
+  "Presence Penalty": "存在惩罚",
+  "Frequency Penalty": "频率惩罚"
 }

--- a/src/_locales/zh-hant/main.json
+++ b/src/_locales/zh-hant/main.json
@@ -159,5 +159,7 @@
   "Gemini (Web)": "Gemini (網頁版)",
   "Type": "類型",
   "Mode": "模式",
-  "Custom": "自訂"
+  "Custom": "自訂",
+  "Presence Penalty": "出現懲罰 (Presence Penalty)",
+  "Frequency Penalty": "頻率懲罰 (Frequency Penalty)"
 }

--- a/src/config/index.mjs
+++ b/src/config/index.mjs
@@ -335,6 +335,8 @@ export const defaultConfig = {
   maxResponseTokenLength: 1000,
   maxConversationContextLength: 9,
   temperature: 1,
+  presence_penalty: 0,
+  frequency_penalty: 0,
   customChatGptWebApiUrl: 'https://chatgpt.com',
   customChatGptWebApiPath: '/backend-api/conversation',
   customOpenAiApiUrl: 'https://api.openai.com',

--- a/src/popup/sections/AdvancedPart.jsx
+++ b/src/popup/sections/AdvancedPart.jsx
@@ -56,6 +56,34 @@ function ApiParams({ config, updateConfig }) {
           }}
         />
       </label>
+      <label>
+        {t('Presence Penalty') + `: ${config.presence_penalty}`}
+        <input
+          type="range"
+          min="-2"
+          max="2"
+          step="0.1"
+          value={config.presence_penalty}
+          onChange={(e) => {
+            const value = parseFloatWithClamp(e.target.value, 0, -2, 2)
+            updateConfig({ presence_penalty: value })
+          }}
+        />
+      </label>
+      <label>
+        {t('Frequency Penalty') + `: ${config.frequency_penalty}`}
+        <input
+          type="range"
+          min="-2"
+          max="2"
+          step="0.1"
+          value={config.frequency_penalty}
+          onChange={(e) => {
+            const value = parseFloatWithClamp(e.target.value, 0, -2, 2)
+            updateConfig({ frequency_penalty: value })
+          }}
+        />
+      </label>
     </>
   )
 }

--- a/src/services/apis/azure-openai-api.mjs
+++ b/src/services/apis/azure-openai-api.mjs
@@ -40,6 +40,8 @@ export async function generateAnswersWithAzureOpenaiApi(port, question, session)
         stream: true,
         max_tokens: config.maxResponseTokenLength,
         temperature: config.temperature,
+        presence_penalty: config.presence_penalty,
+        frequency_penalty: config.frequency_penalty,
       }),
       onMessage(message) {
         console.debug('sse message', message)

--- a/src/services/apis/openai-api.mjs
+++ b/src/services/apis/openai-api.mjs
@@ -48,6 +48,8 @@ export async function generateAnswersWithGptCompletionApi(port, question, sessio
       stream: true,
       max_tokens: config.maxResponseTokenLength,
       temperature: config.temperature,
+      presence_penalty: config.presence_penalty,
+      frequency_penalty: config.frequency_penalty,
       stop: '\nHuman',
     }),
     onMessage(message) {
@@ -145,6 +147,8 @@ export async function generateAnswersWithChatgptApiCompat(
       stream: true,
       max_tokens: config.maxResponseTokenLength,
       temperature: config.temperature,
+      presence_penalty: config.presence_penalty,
+      frequency_penalty: config.frequency_penalty,
       ...extraBody,
     }),
     onMessage(message) {


### PR DESCRIPTION
The frequency and presence penalties help reduce the likelihood of repetitive token sequences, allowing for more varied and contextually appropriate outputs.

By implementing these options, we can gain finer control over the AI's behavior, leading to improved content generation.

Reference docs:
- https://platform.openai.com/docs/api-reference/chat/create#chat-create-frequency_penalty
- https://platform.openai.com/docs/api-reference/chat/create#chat-create-presence_penalty
- https://platform.openai.com/docs/advanced-usage/frequency-and-presence-penalties