### PR TITLE
fix: avoid crash when readability parser returns null

### DIFF
--- a/src/utils/get-core-content-text.mjs
+++ b/src/utils/get-core-content-text.mjs
@@ -71,11 +71,13 @@ export function getCoreContentText() {
   }
 
   if (isProbablyReaderable(document)) {
-    let article = new Readability(document.cloneNode(true), {
+    const article = new Readability(document.cloneNode(true), {
       keepClasses: true,
     }).parse()
-    console.log('readerable')
-    return postProcessText(article.textContent)
+    if (article?.textContent) {
+      console.log('readerable')
+      return postProcessText(article.textContent)
+    }
   }
 
   const largestElement = findLargestElement(document.body)


### PR DESCRIPTION
It's a patch generated by OpenAI Codex, which we could use as a trial run and test lab. We can also review the feedback from other agents.

Summary from GitHub Copilot:

> This pull request makes a small improvement to the `getCoreContentText` function in `src/utils/get-core-content-text.mjs` by ensuring safer access to the `textContent` property of the `article` object and updating the variable declaration to use `const` for better code clarity and consistency.