### PR TITLE
Add Claude Sonnet 4.5 model support

### DIFF
--- a/src/config/index.mjs
+++ b/src/config/index.mjs
@@ -82,6 +82,7 @@ export const claudeApiModelKeys = [
   'claudeOpus4Api',
   'claudeOpus41Api',
   'claudeSonnet4Api',
+  'claudeSonnet45Api',
 ]
 export const chatglmApiModelKeys = ['chatglmTurbo', 'chatglm4', 'chatglmEmohaa', 'chatglmCharGLM3']
 export const githubThirdPartyApiModelKeys = ['waylaidwandererApi']
@@ -110,6 +111,7 @@ export const moonshotApiModelKeys = [
 export const deepSeekApiModelKeys = ['deepseek_chat', 'deepseek_reasoner']
 export const openRouterApiModelKeys = [
   'openRouter_anthropic_claude_sonnet4',
+  'openRouter_anthropic_claude_sonnet4_5',
   'openRouter_anthropic_claude_3_7_sonnet',
   'openRouter_google_gemini_2_5_pro',
   'openRouter_google_gemini_2_5_flash',
@@ -120,6 +122,7 @@ export const openRouterApiModelKeys = [
 export const aimlApiModelKeys = [
   'aiml_anthropic_claude_opus_4',
   'aiml_anthropic_claude_sonnet_4',
+  'aiml_anthropic_claude_sonnet_4_5',
   'aiml_anthropic_claude_opus_4_1',
   'aiml_claude_3_7_sonnet_20250219',
   'aiml_google_gemini_2_5_pro_preview_05_06',
@@ -290,6 +293,10 @@ export const Models = {
     value: 'claude-sonnet-4-20250514',
     desc: 'Claude.ai (API, Claude Sonnet 4)',
   },
+  claudeSonnet45Api: {
+    value: 'claude-sonnet-4-5-20250929',
+    desc: 'Claude.ai (API, Claude Sonnet 4.5)',
+  },
 
   bingFree4: { value: '', desc: 'Bing (Web, GPT-4)' },
   bingFreeSydney: { value: '', desc: 'Bing (Web, GPT-4, Sydney)' },
@@ -372,6 +379,10 @@ export const Models = {
     value: 'anthropic/claude-sonnet-4',
     desc: 'OpenRouter (Claude Sonnet 4)',
   },
+  openRouter_anthropic_claude_sonnet4_5: {
+    value: 'anthropic/claude-sonnet-4.5',
+    desc: 'OpenRouter (Claude Sonnet 4.5)',
+  },
   openRouter_anthropic_claude_3_7_sonnet: {
     value: 'anthropic/claude-3.7-sonnet',
     desc: 'OpenRouter (Claude 3.7 Sonnet)',
@@ -408,6 +419,10 @@ export const Models = {
   aiml_anthropic_claude_sonnet_4: {
     value: 'anthropic/claude-sonnet-4',
     desc: 'AIML (Claude Sonnet 4)',
+  },
+  aiml_anthropic_claude_sonnet_4_5: {
+    value: 'anthropic/claude-sonnet-4-5',
+    desc: 'AIML (Claude Sonnet 4.5)',
   },
   aiml_claude_3_7_sonnet_20250219: {
     value: 'claude-3-7-sonnet-20250219',
@@ -538,7 +553,7 @@ export const defaultConfig = {
     'ollamaModel',
     'customModel',
     'azureOpenAi',
-    'openRouter_anthropic_claude_sonnet4',
+    'openRouter_anthropic_claude_sonnet4_5',
     'openRouter_google_gemini_2_5_pro',
     'openRouter_openai_o3',
   ],


### PR DESCRIPTION
### **User description**
- Register `claudeSonnet45Api` with the Anthropic API list using the `claude-sonnet-4-5-20250929` identifier.
- Add OpenRouter (`anthropic/claude-sonnet-4.5`) and AIML (`anthropic/claude-sonnet-4-5`) options to keep providers in sync.
- Update the default OpenRouter model to Sonnet 4.5 so new installs use the latest Claude Sonnet model.

Reference:
- https://www.anthropic.com/news/claude-sonnet-4-5


___

### **PR Type**
Enhancement


___

### **Description**
- Add Claude Sonnet 4.5 model support across providers

- Register new model with Anthropic API configuration

- Update default OpenRouter model to latest version

- Maintain provider synchronization for new model


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Claude Sonnet 4.5 Model"] --> B["Anthropic API"]
  A --> C["OpenRouter Provider"]
  A --> D["AIML Provider"]
  E["Default Configuration"] --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.mjs</strong><dd><code>Add Claude Sonnet 4.5 model configurations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/config/index.mjs

<ul><li>Add <code>claudeSonnet45Api</code> to Anthropic API model keys<br> <li> Register new model configurations for all three providers<br> <li> Update default OpenRouter model to Sonnet 4.5<br> <li> Add model definitions with proper identifiers and descriptions</ul>


</details>


  </td>
  <td><a href="https://github.com/ChatGPTBox-dev/chatGPTBox/pull/895/files#diff-8e337760bb5ef388a27cd88efc59eac53bddeda06a3885e04022ecb644c330f1">+16/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for Claude Sonnet 4.5 across providers, including Anthropic, OpenRouter, and AIML. Users can now select this model in presets.
- Chores
  - Updated the default active model to the Claude Sonnet 4.5 variant via OpenRouter for improved quality and consistency. Users may notice upgraded responses without changing settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->