### PR TITLE
Update dated caniuse-lite package to the latest in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3543,9 +3543,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001696",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001696.tgz",
-      "integrity": "sha512-pDCPkvzfa39ehJtJ+OwGT/2yvT2SbjfHhiIW2LWOAcMQ7BzwxT/XuyUp4OTOd0XFWA6BKw0JalnBHgSi5DGJBQ==",
+      "version": "1.0.30001751",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001751.tgz",
+      "integrity": "sha512-A0QJhug0Ly64Ii3eIqHu5X51ebln3k4yTUkY1j8drqpWHVreg/VLijN48cZ1bYPiqOQuqpkIKnzr/Ul8V+p6Cw==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
### **User description**
Run `npx update-browserslist-db@latest` to address the following outdated notice of `caniuse-lite` during building the extension, ensuring updated browser data:

```
Browserslist: caniuse-lite is outdated.  Please run:
npx update-browserslist-db@latest
Why you should do it regularly: https://github.com/browserslist/update-db#readme
```


___

### **PR Type**
Enhancement


___

### **Description**
- Updates `caniuse-lite` package to the latest version in `package-lock.json`

- Runs `npx update-browserslist-db@latest` to address outdated browser data notice

- Ensures updated browser compatibility data is available during extension builds

- Resolves the "caniuse-lite is outdated" warning that appears during the build process


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Outdated caniuse-lite"] -- "npx update-browserslist-db@latest" --> B["Updated package-lock.json"]
  B --> C["Latest browser data"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody></tr></tbody></table>

</details>

___

