### PR TITLE
Improve side panel drawer UX - toggleable drawer, label

### DIFF
--- a/src/components/ConversationCard/index.jsx
+++ b/src/components/ConversationCard/index.jsx
@@ -347,7 +347,11 @@ function ConversationCard(props) {
           className="gpt-util-group"
           style={{
             padding: '15px 0 15px 15px',
-            ...(props.notClampSize ? {} : { flexGrow: isSafari() ? 0 : 1 }),
+            ...(props.pageMode
+              ? { flexGrow: 1, minWidth: 0 }
+              : props.notClampSize
+              ? {}
+              : { flexGrow: isSafari() ? 0 : 1 }),
             ...(isSafari() ? { maxWidth: '200px' } : {}),
           }}
         >
@@ -372,11 +376,28 @@ function ConversationCard(props) {
             >
               <Pin size={16} />
             </span>
+          ) : props.onToggleSidebar ? (
+            <button
+              type="button"
+              className="gpt-util-icon gpt-menu-toggle"
+              title="Toggle sidebar"
+              aria-label="Toggle sidebar"
+              aria-expanded={Boolean(props.sidebarOpen)}
+              onClick={(e) => {
+                e.preventDefault()
+                e.stopPropagation()
+                props.onToggleSidebar()
+              }}
+            >
+              ☰
+            </button>
           ) : (
             <img src={logo} style="user-select:none;width:20px;height:20px;" />
           )}
           <select
-            style={props.notClampSize ? {} : { width: 0, flexGrow: 1 }}
+            style={
+              props.pageMode || !props.notClampSize ? { width: 0, flexGrow: 1, minWidth: 0 } : {}
+            }
             className="normal-button"
             required
             onChange={(e) => {
@@ -425,7 +446,8 @@ function ConversationCard(props) {
           style={{
             padding: '15px 15px 15px 0',
             justifyContent: 'flex-end',
-            flexGrow: props.draggable && !completeDraggable ? 0 : 1,
+            flexGrow: props.pageMode ? 0 : props.draggable && !completeDraggable ? 0 : 1,
+            flexShrink: 0,
           }}
         >
           {!config.disableWebModeHistory && session && session.conversationId && (
@@ -622,6 +644,8 @@ ConversationCard.propTypes = {
   notClampSize: PropTypes.bool,
   pageMode: PropTypes.bool,
   waitForTrigger: PropTypes.bool,
+  onToggleSidebar: PropTypes.func,
+  sidebarOpen: PropTypes.bool,
 }
 
 export default memo(ConversationCard)

--- a/src/pages/IndependentPanel/styles.scss
+++ b/src/pages/IndependentPanel/styles.scss
@@ -37,10 +37,39 @@
 }
 
 .IndependentPanel {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  min-height: 100vh;
+  background-color: var(--theme-color);
+
+  .gpt-menu-toggle {
+    width: 28px;
+    height: 28px;
+    border: 1px solid var(--theme-border-color);
+    background-color: var(--theme-color);
+    color: var(--font-color);
+    border-radius: 8px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    line-height: 1;
+  }
+
   .chat-container {
     display: flex;
     width: 100%;
-    height: 100%;
+    flex: 1 1 auto;
+    flex-grow: 1;
+    min-height: 0;
+    min-width: 0;
+    overflow: hidden;
+    position: relative;
+  }
+
+  .chat-sidebar-backdrop {
+    display: none;
   }
 
   .chat-sidebar {
@@ -51,6 +80,7 @@
     background-color: var(--theme-color);
     transition: width 0.3s, min-width 0.3s;
     padding: 10px;
+    flex-shrink: 0;
 
     ::-webkit-scrollbar {
       background-color: var(--theme-color);
@@ -67,14 +97,45 @@
   }
 
   .chat-sidebar.collapsed {
-    min-width: 60px;
-    width: 60px;
+    min-width: 0;
+    width: 0;
+    padding: 0;
   }
 
-  .chat-sidebar:hover,
-  .chat-sidebar:not(.collapsed) {
-    min-width: 250px;
-    width: 250px;
+  .chat-sidebar-content {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+    gap: 15px;
+    overflow: hidden;
+    min-height: 0;
+  }
+
+  .chat-sidebar-topbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    margin: -10px -10px 0;
+    height: 78px;
+    padding: 0 15px;
+    box-sizing: border-box;
+    border-bottom: 1px solid var(--theme-border-color);
+  }
+
+  .chat-sidebar-logo {
+    width: 20px;
+    height: 20px;
+    flex: 0 0 auto;
+  }
+
+  .chat-sidebar-topbar .gpt-menu-toggle {
+    width: 28px;
+    height: 28px;
+  }
+
+  .chat-sidebar.collapsed .chat-sidebar-content {
+    display: none;
   }
 
   .chat-sidebar-button-group {
@@ -100,6 +161,72 @@
     flex-grow: 1;
     border: 1px solid var(--theme-border-color);
     background-color: var(--theme-color);
+    min-width: 0;
+    overflow: hidden;
+  }
+
+  .chat-content .chatgptbox-container {
+    min-width: 0;
+    height: 100%;
+  }
+
+  .chat-content .gpt-inner {
+    min-width: 0;
+    height: 100%;
+  }
+
+  .chat-content .gpt-header {
+    flex-wrap: wrap;
+    row-gap: 8px;
+  }
+
+  .chat-content .gpt-header > .gpt-util-group {
+    min-width: 0;
+  }
+
+  .chat-content .gpt-header > .gpt-util-group:first-child select.normal-button {
+    width: 0;
+    flex: 1 1 auto;
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  @media screen and (max-width: 600px) {
+    .chat-container.sidebar-open .chat-sidebar-backdrop {
+      display: block;
+      position: absolute;
+      inset: 0;
+      background-color: rgba(0, 0, 0, 0.35);
+      z-index: 10;
+    }
+
+    .chat-sidebar {
+      position: absolute;
+      top: 0;
+      left: 0;
+      height: 100%;
+      width: min(280px, 85vw);
+      min-width: 0;
+      transform: translateX(0);
+      transition: transform 0.3s;
+      visibility: visible;
+      z-index: 11;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+    }
+
+    .chat-sidebar.collapsed {
+      width: min(280px, 85vw);
+      min-width: 0;
+      transform: translateX(-105%);
+      padding: 10px;
+      visibility: hidden;
+      pointer-events: none;
+      transition: transform 0.3s, visibility 0s linear 0.3s;
+    }
+
+    .chat-sidebar.collapsed .chat-sidebar-content {
+      display: flex;
+    }
   }
 
   .normal-button {

--- a/src/pages/IndependentPanel/styles.scss
+++ b/src/pages/IndependentPanel/styles.scss
@@ -118,15 +118,30 @@
     gap: 10px;
     margin: -10px -10px 0;
     height: 78px;
-    padding: 0 15px;
+    padding: 15px;
     box-sizing: border-box;
     border-bottom: 1px solid var(--theme-border-color);
+  }
+
+  .chat-sidebar-brand-group {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
   }
 
   .chat-sidebar-logo {
     width: 20px;
     height: 20px;
     flex: 0 0 auto;
+  }
+
+  .chat-sidebar-brand {
+    color: var(--font-color);
+    font-weight: 600;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .chat-sidebar-topbar .gpt-menu-toggle {


### PR DESCRIPTION
### **User description**
The hover to expand drawer is quite intrusive at small widths (eg the Side Panel), and especially there as the mouse crosses the threshold frequently. Changed it to be manually activated upon click. This also has the advantage of more horizontal space in the sidepanel view too. Added ChatGPTBox label next to logo
---
  - Changes
      - Session sidebar is click-to-toggle (no hover behavior).
      - Narrow widths use an off-canvas drawer + backdrop; selecting a session/settings auto-closes on small screens.
      - Standalone IndependentPanel (tab/window) auto-opens the drawer on wide screens (detected via tabs.getCurrent()), while Chrome side panel
        stays closed by default.
      - Drawer header includes logo + “ChatGPTBox” label + close button; heights align with the conversation header.
      - Header/layout is constrained to prevent overflow at small sidebar widths; IndependentPanel stays full-height with few messages.
  - Files
      - src/pages/IndependentPanel/App.jsx
      - src/pages/IndependentPanel/styles.scss
      - src/components/ConversationCard/index.jsx
  - Manual test notes
      - Side panel: burger toggles drawer; backdrop click closes; no overflow when narrow.
      - IndependentPanel tab: on wide window, drawer starts open; still toggleable.

Conversation Page view:
<img width="3366" height="846" alt="image" src="https://github.com/user-attachments/assets/59b80564-f9ee-4d5a-853f-74505ccb9e8e" />

Sidepanel view:
<img width="622" height="600" alt="image" src="https://github.com/user-attachments/assets/39e89b76-7d51-4fe2-8331-977058e2dfcf" />
Sidepanel drawer opened view:
<img width="770" height="590" alt="image" src="https://github.com/user-attachments/assets/938a0706-cb3b-4ccc-bd0b-8d61b4213075" />


___

### **PR Type**
Enhancement


___

### **Description**
- Implement click-to-toggle sidebar with off-canvas drawer on narrow screens

- Add drawer header with logo, brand label, and close button

- Auto-open drawer on wide IndependentPanel tabs, keep side panel closed by default

- Improve responsive layout with proper flex constraints and overflow handling

- Add sidebar toggle button to conversation header for page mode


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User Interaction"] -->|Click Toggle| B["Sidebar State"]
  B -->|Wide Screen| C["Auto-open IndependentPanel"]
  B -->|Narrow Screen| D["Off-canvas Drawer"]
  D -->|Backdrop Click| E["Close Sidebar"]
  F["Drawer Header"] -->|Logo + Brand| G["Visual Identity"]
  F -->|Close Button| E
  H["Responsive Layout"] -->|Flex Constraints| I["Prevent Overflow"]
  I -->|Min-width/Height| J["Proper Content Sizing"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>styles.scss</strong><dd><code>Responsive drawer layout with off-canvas positioning</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/pages/IndependentPanel/styles.scss

<ul><li>Convert layout to flexbox with full viewport height and proper flex <br>constraints<br> <li> Add drawer header styles with logo, brand label, and close button<br> <li> Implement off-canvas drawer positioning and backdrop for screens <br>≤600px width<br> <li> Add responsive media query for narrow screens with slide-out animation<br> <li> Fix overflow handling in chat content and header with min-width <br>constraints</ul>


</details>


  </td>
  <td><a href="https://github.com/ChatGPTBox-dev/chatGPTBox/pull/911/files#diff-065bc5b658fa3de3e55ae6aff8f975d7951fe64110b3fe06976fbbd838779062">+149/-7</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>App.jsx</strong><dd><code>Add auto-open logic and sidebar state management</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/pages/IndependentPanel/App.jsx

<ul><li>Add auto-open logic for drawer on wide IndependentPanel tabs using <br>tabs.getCurrent()<br> <li> Implement closeSidebar and closeSidebarIfOverlay functions for <br>responsive behavior<br> <li> Add hasUserToggledRef to track manual toggle state and prevent <br>auto-open override<br> <li> Restructure sidebar content into chat-sidebar-content wrapper with <br>topbar header<br> <li> Add logo import and pass sidebar state/toggle props to <br>ConversationCard component<br> <li> Auto-close sidebar on session selection or settings click on narrow <br>screens</ul>


</details>


  </td>
  <td><a href="https://github.com/ChatGPTBox-dev/chatGPTBox/pull/911/files#diff-f0a16509bbbf739636815736a06b2284243d31338f43a9326095f4499576765f">+106/-55</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.jsx</strong><dd><code>Add sidebar toggle button and pageMode layout support</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/ConversationCard/index.jsx

<ul><li>Add pageMode prop handling for flexible header layout with proper <br>flex-grow behavior<br> <li> Add onToggleSidebar callback and sidebarOpen prop for sidebar toggle <br>button<br> <li> Render hamburger menu toggle button in header when onToggleSidebar is <br>provided<br> <li> Update select element styling to use minWidth constraint in page mode<br> <li> Add flexShrink constraint to right utility group for proper layout <br>stability<br> <li> Update PropTypes to include new onToggleSidebar and sidebarOpen props</ul>


</details>


  </td>
  <td><a href="https://github.com/ChatGPTBox-dev/chatGPTBox/pull/911/files#diff-d65bf278a17fe663e11ce6072eb7e8dbd89c6b2b81de1fa2ad6b1a69d03b471f">+27/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a collapsible sidebar toggle button for easy content navigation
  * Sidebar now auto-opens on wide viewports and collapses on mobile
  * Added backdrop overlay to close sidebar interaction

* **UI/UX Improvements**
  * Restructured sidebar with new header containing logo and branding
  * Enhanced responsive design with modal-like mobile sidebar behavior
  * Improved layout spacing and alignment across interface components

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->