### PR TITLE
Add Anthropic Claude Opus 4.5 & 4.6

### DIFF
--- a/src/config/index.mjs
+++ b/src/config/index.mjs
@@ -82,6 +82,8 @@ export const claudeApiModelKeys = [
   'claude37SonnetApi',
   'claudeOpus4Api',
   'claudeOpus41Api',
+  'claudeOpus45Api',
+  'claudeOpus46Api',
   'claudeSonnet4Api',
   'claudeSonnet45Api',
   'claudeHaiku45Api',
@@ -114,6 +116,8 @@ export const deepSeekApiModelKeys = ['deepseek_chat', 'deepseek_reasoner']
 export const openRouterApiModelKeys = [
   'openRouter_anthropic_claude_sonnet4',
   'openRouter_anthropic_claude_sonnet4_5',
+  'openRouter_anthropic_claude_opus4_5',
+  'openRouter_anthropic_claude_opus4_6',
   'openRouter_anthropic_claude_haiku4_5',
   'openRouter_anthropic_claude_3_7_sonnet',
   'openRouter_google_gemini_2_5_pro',
@@ -293,6 +297,14 @@ export const Models = {
     value: 'claude-opus-4-1-20250805',
     desc: 'Claude.ai (API, Claude Opus 4.1)',
   },
+  claudeOpus45Api: {
+    value: 'claude-opus-4-5',
+    desc: 'Claude.ai (API, Claude Opus 4.5)',
+  },
+  claudeOpus46Api: {
+    value: 'claude-opus-4-6',
+    desc: 'Claude.ai (API, Claude Opus 4.6)',
+  },
   claudeSonnet4Api: {
     value: 'claude-sonnet-4-20250514',
     desc: 'Claude.ai (API, Claude Sonnet 4)',
@@ -394,6 +406,14 @@ export const Models = {
   openRouter_anthropic_claude_haiku4_5: {
     value: 'anthropic/claude-haiku-4.5',
     desc: 'OpenRouter (Claude Haiku 4.5)',
+  },
+  openRouter_anthropic_claude_opus4_5: {
+    value: 'anthropic/claude-opus-4.5',
+    desc: 'OpenRouter (Claude Opus 4.5)',
+  },
+  openRouter_anthropic_claude_opus4_6: {
+    value: 'anthropic/claude-opus-4.6',
+    desc: 'OpenRouter (Claude Opus 4.6)',
   },
   openRouter_anthropic_claude_3_7_sonnet: {
     value: 'anthropic/claude-3.7-sonnet',


### PR DESCRIPTION
### **User description**
Reference:
- https://www.anthropic.com/news/claude-opus-4-5
- https://www.anthropic.com/news/claude-opus-4-6
- https://docs.anthropic.com/en/docs/about-claude/models


___

### **PR Type**
Enhancement


___

### **Description**
- Add Claude Opus 4.5 and 4.6 model support

- Register new models in Claude API configuration

- Add OpenRouter integration for Opus 4.5 and 4.6


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Claude Opus 4.5<br/>4.6 Models"] --> B["Claude API<br/>Config Keys"]
  A --> C["Model Definitions<br/>with API Values"]
  A --> D["OpenRouter<br/>Integration"]
  B --> E["claudeOpus45Api<br/>claudeOpus46Api"]
  C --> F["claude-opus-4-5<br/>claude-opus-4-6"]
  D --> G["openRouter_anthropic<br/>_claude_opus4_5/6"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.mjs</strong><dd><code>Register Claude Opus 4.5 and 4.6 models</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/config/index.mjs

<ul><li>Added <code>claudeOpus45Api</code> and <code>claudeOpus46Api</code> to <code>claudeApiModelKeys</code> array<br> <li> Added <code>openRouter_anthropic_claude_opus4_5</code> and <br><code>openRouter_anthropic_claude_opus4_6</code> to <code>openRouterApiModelKeys</code> array<br> <li> Defined model configurations for Claude Opus 4.5 with value <br><code>claude-opus-4-5</code><br> <li> Defined model configurations for Claude Opus 4.6 with value <br><code>claude-opus-4-6</code><br> <li> Added OpenRouter model definitions for both Opus 4.5 and 4.6 variants</ul>


</details>


  </td>
  <td><a href="https://github.com/ChatGPTBox-dev/chatGPTBox/pull/918/files#diff-8e337760bb5ef388a27cd88efc59eac53bddeda06a3885e04022ecb644c330f1">+20/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Claude Opus 4.5 and Claude Opus 4.6 models, available through both Claude API and OpenRouter integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->