### PR TITLE
Handle GPT-5 token params by provider

### DIFF
--- a/src/services/apis/custom-api.mjs
+++ b/src/services/apis/custom-api.mjs
@@ -10,6 +10,7 @@ import { fetchSSE } from '../../utils/fetch-sse.mjs'
 import { getConversationPairs } from '../../utils/get-conversation-pairs.mjs'
 import { isEmpty } from 'lodash-es'
 import { pushRecord, setAbortController } from './shared.mjs'
+import { getChatCompletionsTokenParams } from './openai-token-params.mjs'
 
 /**
  * @param {Browser.Runtime.Port} port
@@ -55,7 +56,7 @@ export async function generateAnswersWithCustomApi(
       messages: prompt,
       model: modelName,
       stream: true,
-      max_tokens: config.maxResponseTokenLength,
+      ...getChatCompletionsTokenParams('custom', modelName, config.maxResponseTokenLength),
       temperature: config.temperature,
     }),
     onMessage(message) {

--- a/src/services/apis/openai-token-params.mjs
+++ b/src/services/apis/openai-token-params.mjs
@@ -1,0 +1,21 @@
+const GPT5_CHAT_COMPLETIONS_MODEL_PATTERN = /(^|\/)gpt-5([.-]|$)/
+
+function shouldUseMaxCompletionTokens(provider, model) {
+  const normalizedProvider = String(provider || '').toLowerCase()
+  const normalizedModel = String(model || '').toLowerCase()
+
+  switch (true) {
+    case normalizedProvider === 'openai' &&
+      GPT5_CHAT_COMPLETIONS_MODEL_PATTERN.test(normalizedModel):
+      return true
+    default:
+      return false
+  }
+}
+
+export function getChatCompletionsTokenParams(provider, model, maxResponseTokenLength) {
+  if (shouldUseMaxCompletionTokens(provider, model))
+    return { max_completion_tokens: maxResponseTokenLength }
+
+  return { max_tokens: maxResponseTokenLength }
+}

--- a/src/services/apis/openai-token-params.test.mjs
+++ b/src/services/apis/openai-token-params.test.mjs
@@ -1,0 +1,57 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { getChatCompletionsTokenParams } from './openai-token-params.mjs'
+
+test('uses max_completion_tokens for gpt-5.x chat models', () => {
+  assert.deepEqual(getChatCompletionsTokenParams('openai', 'gpt-5.2-chat-latest', 1024), {
+    max_completion_tokens: 1024,
+  })
+})
+
+test('uses max_completion_tokens for provider-prefixed gpt-5.x models', () => {
+  assert.deepEqual(getChatCompletionsTokenParams('openai', 'openai/gpt-5.2', 2048), {
+    max_completion_tokens: 2048,
+  })
+})
+
+test('uses max_completion_tokens for gpt-5 baseline model name', () => {
+  assert.deepEqual(getChatCompletionsTokenParams('openai', 'gpt-5', 1536), {
+    max_completion_tokens: 1536,
+  })
+})
+
+test('uses max_tokens for non gpt-5 chat models', () => {
+  assert.deepEqual(getChatCompletionsTokenParams('openai', 'gpt-4o', 512), {
+    max_tokens: 512,
+  })
+})
+
+test('uses max_tokens for lookalike model names', () => {
+  assert.deepEqual(getChatCompletionsTokenParams('openai', 'my-gpt-5-clone', 640), {
+    max_tokens: 640,
+  })
+})
+
+test('uses max_tokens for empty model values', () => {
+  assert.deepEqual(getChatCompletionsTokenParams('openai', '', 256), {
+    max_tokens: 256,
+  })
+})
+
+test('uses max_tokens for non OpenAI providers even with gpt-5 models', () => {
+  assert.deepEqual(getChatCompletionsTokenParams('some-proxy-provider', 'openai/gpt-5.2', 257), {
+    max_tokens: 257,
+  })
+})
+
+test('uses max_completion_tokens for mixed-case OpenAI provider and model', () => {
+  assert.deepEqual(getChatCompletionsTokenParams('OpenAI', 'GPT-5.1', 258), {
+    max_completion_tokens: 258,
+  })
+})
+
+test('uses max_tokens when provider is undefined', () => {
+  assert.deepEqual(getChatCompletionsTokenParams(undefined, 'gpt-5.1', 259), {
+    max_tokens: 259,
+  })
+})


### PR DESCRIPTION
Use max_completion_tokens for OpenAI GPT-5-family Chat Completions and
keep max_tokens for non-openai or non-GPT-5-family paths.

Observed error on GPT-5.1-family responses:
Unsupported parameter: 'max_tokens' is not supported with this model.
Use 'max_completion_tokens' instead.

GitHub Copilot PR summary:

> This pull request adds logic to correctly select the token parameter (`max_tokens` vs. `max_completion_tokens`) when calling chat completion APIs, specifically handling new requirements for OpenAI's GPT-5 chat models. The change is applied in both the OpenAI and custom API integrations, and is thoroughly tested with new unit tests.
> 
> **Token parameter selection improvements:**
> 
> * Introduced `getChatCompletionsTokenParams` in `openai-token-params.mjs` to return `max_completion_tokens` for OpenAI GPT-5 chat models, and `max_tokens` for all other models and providers. This ensures API compatibility as OpenAI transitions to the new parameter.
> * Updated `generateAnswersWithCustomApi` and `generateAnswersWithChatgptApiCompat` to use `getChatCompletionsTokenParams` instead of hardcoding the token parameter, ensuring consistent parameter handling across custom and OpenAI APIs. [[1]](diffhunk://#diff-ed0979d1c89a77cc0b6c60b865b1f2e4f5217a4931ec8f4056381a283de66b02R13) [[2]](diffhunk://#diff-ed0979d1c89a77cc0b6c60b865b1f2e4f5217a4931ec8f4056381a283de66b02L58-R59) [[3]](diffhunk://#diff-b817f1a71787e1acd00caa2811609b5984139009ad81aa78389a5240e8038adbR9) [[4]](diffhunk://#diff-b817f1a71787e1acd00caa2811609b5984139009ad81aa78389a5240e8038adbL146-R150)
> 
> **API function signature and usage updates:**
> 
> * Modified `generateAnswersWithChatgptApiCompat` and its callers to accept a `provider` argument, enabling correct parameter selection based on the API provider. [[1]](diffhunk://#diff-b817f1a71787e1acd00caa2811609b5984139009ad81aa78389a5240e8038adbR107-R108) [[2]](diffhunk://#diff-b817f1a71787e1acd00caa2811609b5984139009ad81aa78389a5240e8038adbR119)
> 
> **Testing:**
> 
> * Added comprehensive tests for `getChatCompletionsTokenParams` to verify correct behavior for various provider/model combinations, including OpenAI GPT-5 models, lookalike names, and edge cases.
> 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved token-parameter handling for better compatibility across AI providers and models, including explicit support for newer OpenAI chat models and avoidance of conflicting token fields in requests.
* **Tests**
  * Added comprehensive unit tests covering token-parameter selection across model name patterns, providers, casing, and edge cases to ensure reliable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->