### PR TITLE
Add Node test script to npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dev": "node build.mjs --development",
     "analyze": "node build.mjs --analyze",
     "lint": "eslint --ext .js,.mjs,.jsx .",
+    "test": "node --import ./tests/setup/browser-shim.mjs --test",
     "lint:fix": "eslint --ext .js,.mjs,.jsx . --fix",
     "pretty": "prettier --write ./**/*.{js,mjs,jsx,json,css,scss}",
     "stage": "run-script-os",

--- a/tests/setup/browser-shim.mjs
+++ b/tests/setup/browser-shim.mjs
@@ -1,0 +1,200 @@
+// Minimal browser-extension API shim for Node test runtime.
+// Scope is intentionally small: only APIs used by current unit tests are mocked.
+const createEvent = () => {
+  const listeners = new Set()
+  return {
+    addListener(listener) {
+      listeners.add(listener)
+    },
+    removeListener(listener) {
+      listeners.delete(listener)
+    },
+    hasListener(listener) {
+      return listeners.has(listener)
+    },
+    _trigger(...args) {
+      for (const listener of Array.from(listeners)) {
+        listener(...args)
+      }
+    },
+    _clear() {
+      listeners.clear()
+    },
+    _size() {
+      return listeners.size
+    },
+  }
+}
+
+const runtimeOnMessage = createEvent()
+const commandsOnCommand = createEvent()
+
+const createStorageState = (values = {}) => Object.assign(Object.create(null), values)
+let storageState = createStorageState()
+
+const resolveStorageGet = (keys) => {
+  if (keys === null || keys === undefined) return { ...storageState }
+
+  if (typeof keys === 'string') {
+    return Object.hasOwn(storageState, keys) ? { [keys]: storageState[keys] } : {}
+  }
+
+  if (Array.isArray(keys)) {
+    const result = {}
+    for (const key of keys) {
+      if (Object.hasOwn(storageState, key)) result[key] = storageState[key]
+    }
+    return result
+  }
+
+  if (typeof keys === 'object') {
+    const result = {}
+    for (const [key, defaultValue] of Object.entries(keys)) {
+      if (Object.hasOwn(storageState, key)) result[key] = storageState[key]
+      else result[key] = defaultValue
+    }
+    return result
+  }
+
+  return {}
+}
+
+const storageLocal = {
+  get(keys, callback) {
+    const result = resolveStorageGet(keys)
+    if (typeof callback === 'function') {
+      queueMicrotask(() => callback(result))
+      return
+    }
+    return Promise.resolve(result)
+  },
+  set(items, callback) {
+    Object.assign(storageState, items ?? {})
+    if (typeof callback === 'function') {
+      queueMicrotask(() => callback())
+      return
+    }
+    return Promise.resolve()
+  },
+  clear(callback) {
+    storageState = createStorageState()
+    if (typeof callback === 'function') {
+      queueMicrotask(() => callback())
+      return
+    }
+    return Promise.resolve()
+  },
+}
+
+const tabs = {
+  query(_queryInfo, callback) {
+    const result = []
+    if (typeof callback === 'function') {
+      queueMicrotask(() => callback(result))
+      return
+    }
+    return Promise.resolve(result)
+  },
+  sendMessage(_tabId, _message, optionsOrCallback, callback) {
+    const cb =
+      typeof optionsOrCallback === 'function'
+        ? optionsOrCallback
+        : typeof callback === 'function'
+        ? callback
+        : null
+    if (cb) {
+      queueMicrotask(() => cb())
+      return
+    }
+    return Promise.resolve()
+  },
+}
+
+const windows = {
+  create(_createData, callback) {
+    const result = { id: 1 }
+    if (typeof callback === 'function') {
+      queueMicrotask(() => callback(result))
+      return
+    }
+    return Promise.resolve(result)
+  },
+  update(_windowId, _updateInfo, callback) {
+    const result = { id: 1 }
+    if (typeof callback === 'function') {
+      queueMicrotask(() => callback(result))
+      return
+    }
+    return Promise.resolve(result)
+  },
+}
+
+const runtime = {
+  id: 'test-extension-id',
+  onMessage: runtimeOnMessage,
+  sendMessage(_message, optionsOrCallback, callback) {
+    const cb =
+      typeof optionsOrCallback === 'function'
+        ? optionsOrCallback
+        : typeof callback === 'function'
+        ? callback
+        : null
+    if (cb) {
+      queueMicrotask(() => cb())
+      return
+    }
+    return Promise.resolve()
+  },
+  getURL(path) {
+    return `chrome-extension://test/${path}`
+  },
+}
+
+const chromeShim = {
+  runtime,
+  storage: {
+    local: storageLocal,
+  },
+  tabs,
+  windows,
+  commands: {
+    onCommand: commandsOnCommand,
+  },
+}
+
+if (!globalThis.navigator) {
+  globalThis.navigator = {
+    language: 'en-US',
+    userAgent: 'Mozilla/5.0 (X11; Linux x86_64)',
+  }
+}
+
+if (!globalThis.chrome) {
+  globalThis.chrome = chromeShim
+} else {
+  globalThis.chrome.runtime ||= runtime
+  globalThis.chrome.storage ||= { local: storageLocal }
+  globalThis.chrome.storage.local ||= storageLocal
+  globalThis.chrome.tabs ||= tabs
+  globalThis.chrome.windows ||= windows
+  globalThis.chrome.commands ||= { onCommand: commandsOnCommand }
+}
+
+globalThis.__TEST_BROWSER_SHIM__ = {
+  setStorage(values) {
+    Object.assign(storageState, values)
+  },
+  replaceStorage(values) {
+    storageState = createStorageState(values)
+  },
+  clearStorage() {
+    storageState = createStorageState()
+  },
+  getStorage() {
+    return { ...storageState }
+  },
+  resetEvents() {
+    runtimeOnMessage._clear()
+    commandsOnCommand._clear()
+  },
+}

--- a/tests/unit/helpers/port.mjs
+++ b/tests/unit/helpers/port.mjs
@@ -1,0 +1,44 @@
+export function createFakePort() {
+  const onMessageListeners = new Set()
+  const onDisconnectListeners = new Set()
+  const postedMessages = []
+
+  return {
+    postedMessages,
+    onMessage: {
+      addListener(listener) {
+        onMessageListeners.add(listener)
+      },
+      removeListener(listener) {
+        onMessageListeners.delete(listener)
+      },
+    },
+    onDisconnect: {
+      addListener(listener) {
+        onDisconnectListeners.add(listener)
+      },
+      removeListener(listener) {
+        onDisconnectListeners.delete(listener)
+      },
+    },
+    postMessage(message) {
+      postedMessages.push(message)
+    },
+    emitMessage(message) {
+      for (const listener of Array.from(onMessageListeners)) {
+        listener(message)
+      }
+    },
+    emitDisconnect() {
+      for (const listener of Array.from(onDisconnectListeners)) {
+        listener()
+      }
+    },
+    listenerCounts() {
+      return {
+        onMessage: onMessageListeners.size,
+        onDisconnect: onDisconnectListeners.size,
+      }
+    },
+  }
+}

--- a/tests/unit/helpers/sse-response.mjs
+++ b/tests/unit/helpers/sse-response.mjs
@@ -1,0 +1,28 @@
+const encoder = new TextEncoder()
+
+export function createMockSseResponse(chunks, options = {}) {
+  const { ok = true, status = 200, statusText = 'OK', json = async () => ({}) } = options
+
+  return {
+    ok,
+    status,
+    statusText,
+    json,
+    body: {
+      getReader() {
+        let index = 0
+        return {
+          async read() {
+            if (index >= chunks.length) {
+              return { done: true, value: undefined }
+            }
+
+            const value = encoder.encode(chunks[index])
+            index += 1
+            return { done: false, value }
+          },
+        }
+      },
+    },
+  }
+}

--- a/tests/unit/services/apis/openai-api-compat.test.mjs
+++ b/tests/unit/services/apis/openai-api-compat.test.mjs
@@ -1,0 +1,280 @@
+import assert from 'node:assert/strict'
+import { beforeEach, test } from 'node:test'
+import {
+  generateAnswersWithChatgptApiCompat,
+  generateAnswersWithGptCompletionApi,
+} from '../../../../src/services/apis/openai-api.mjs'
+import { createFakePort } from '../../helpers/port.mjs'
+import { createMockSseResponse } from '../../helpers/sse-response.mjs'
+
+const setStorage = (values) => {
+  globalThis.__TEST_BROWSER_SHIM__.replaceStorage(values)
+}
+
+beforeEach(() => {
+  globalThis.__TEST_BROWSER_SHIM__.clearStorage()
+})
+
+test('generateAnswersWithChatgptApiCompat sends expected request and aggregates SSE deltas', async (t) => {
+  t.mock.method(console, 'debug', () => {})
+  setStorage({
+    maxConversationContextLength: 3,
+    maxResponseTokenLength: 256,
+    temperature: 0.25,
+  })
+
+  const session = {
+    modelName: 'chatgptApi4oMini',
+    conversationRecords: [{ question: 'PrevQ', answer: 'PrevA' }],
+    isRetry: false,
+  }
+  const port = createFakePort()
+
+  let capturedInput
+  let capturedInit
+  t.mock.method(globalThis, 'fetch', async (input, init) => {
+    capturedInput = input
+    capturedInit = init
+    return createMockSseResponse([
+      'data: {"choices":[{"delta":{"content":"Hel"}}]}\n\n',
+      'data: {"choices":[{"delta":{"content":"lo"},"finish_reason":"stop"}]}\n\n',
+    ])
+  })
+
+  await generateAnswersWithChatgptApiCompat(
+    'https://api.example.com/v1',
+    port,
+    'CurrentQ',
+    session,
+    'sk-test',
+  )
+
+  assert.equal(capturedInput, 'https://api.example.com/v1/chat/completions')
+  assert.equal(capturedInit.method, 'POST')
+  assert.equal(capturedInit.headers.Authorization, 'Bearer sk-test')
+
+  const body = JSON.parse(capturedInit.body)
+  assert.equal(body.stream, true)
+  assert.equal(body.max_tokens, 256)
+  assert.equal(body.temperature, 0.25)
+  assert.equal(Array.isArray(body.messages), true)
+  assert.equal(body.messages.length >= 3, true)
+  assert.deepEqual(body.messages[0], { role: 'user', content: 'PrevQ' })
+  assert.deepEqual(body.messages[1], { role: 'assistant', content: 'PrevA' })
+  assert.deepEqual(body.messages.at(-1), { role: 'user', content: 'CurrentQ' })
+
+  assert.equal(
+    port.postedMessages.some((message) => message.done === false && message.answer === 'Hel'),
+    true,
+  )
+  assert.equal(
+    port.postedMessages.some((message) => message.done === false && message.answer === 'Hello'),
+    true,
+  )
+  assert.equal(
+    port.postedMessages.some((message) => message.done === true && message.session === session),
+    true,
+  )
+  assert.deepEqual(port.postedMessages.at(-1), { done: true })
+  assert.deepEqual(session.conversationRecords.at(-1), { question: 'CurrentQ', answer: 'Hello' })
+})
+
+test('generateAnswersWithChatgptApiCompat throws on non-ok response with JSON error body', async (t) => {
+  t.mock.method(console, 'debug', () => {})
+  setStorage({
+    maxConversationContextLength: 3,
+    maxResponseTokenLength: 128,
+    temperature: 0.1,
+  })
+
+  const session = {
+    modelName: 'chatgptApi4oMini',
+    conversationRecords: [],
+    isRetry: false,
+  }
+  const port = createFakePort()
+
+  t.mock.method(globalThis, 'fetch', async () =>
+    createMockSseResponse([], {
+      ok: false,
+      status: 401,
+      statusText: 'Unauthorized',
+      json: async () => ({ error: { message: 'invalid key' } }),
+    }),
+  )
+
+  await assert.rejects(async () => {
+    await generateAnswersWithChatgptApiCompat(
+      'https://api.example.com/v1',
+      port,
+      'CurrentQ',
+      session,
+      'sk-invalid',
+    )
+  }, /invalid key/)
+
+  assert.deepEqual(port.listenerCounts(), { onMessage: 0, onDisconnect: 0 })
+})
+
+test('generateAnswersWithChatgptApiCompat throws on network error', async (t) => {
+  t.mock.method(console, 'debug', () => {})
+  setStorage({
+    maxConversationContextLength: 3,
+    maxResponseTokenLength: 128,
+    temperature: 0.1,
+  })
+
+  const session = {
+    modelName: 'chatgptApi4oMini',
+    conversationRecords: [],
+    isRetry: false,
+  }
+  const port = createFakePort()
+
+  t.mock.method(globalThis, 'fetch', async () => {
+    throw new TypeError('Failed to fetch')
+  })
+
+  await assert.rejects(async () => {
+    await generateAnswersWithChatgptApiCompat(
+      'https://api.example.com/v1',
+      port,
+      'CurrentQ',
+      session,
+      'sk-invalid',
+    )
+  }, /Failed to fetch/)
+
+  assert.deepEqual(port.listenerCounts(), { onMessage: 0, onDisconnect: 0 })
+})
+
+test('generateAnswersWithChatgptApiCompat falls back to status text when JSON error parsing fails', async (t) => {
+  t.mock.method(console, 'debug', () => {})
+  setStorage({
+    maxConversationContextLength: 3,
+    maxResponseTokenLength: 128,
+    temperature: 0.1,
+  })
+
+  const session = {
+    modelName: 'chatgptApi4oMini',
+    conversationRecords: [],
+    isRetry: false,
+  }
+  const port = createFakePort()
+
+  t.mock.method(globalThis, 'fetch', async () =>
+    createMockSseResponse([], {
+      ok: false,
+      status: 502,
+      statusText: 'Bad Gateway',
+      json: async () => {
+        throw new SyntaxError('Unexpected token <')
+      },
+    }),
+  )
+
+  await assert.rejects(async () => {
+    await generateAnswersWithChatgptApiCompat(
+      'https://api.example.com/v1',
+      port,
+      'CurrentQ',
+      session,
+      'sk-invalid',
+    )
+  }, /502 Bad Gateway/)
+
+  assert.deepEqual(port.listenerCounts(), { onMessage: 0, onDisconnect: 0 })
+})
+
+test('generateAnswersWithChatgptApiCompat supports message.content fallback', async (t) => {
+  t.mock.method(console, 'debug', () => {})
+  setStorage({
+    maxConversationContextLength: 2,
+    maxResponseTokenLength: 256,
+    temperature: 0.2,
+  })
+
+  const session = {
+    modelName: 'chatgptApi4oMini',
+    conversationRecords: [{ question: 'PrevQ', answer: 'PrevA' }],
+    isRetry: false,
+  }
+  const port = createFakePort()
+
+  t.mock.method(globalThis, 'fetch', async () =>
+    createMockSseResponse([
+      'data: {"choices":[{"message":{"content":"Final content"},"finish_reason":"stop"}]}\n\n',
+    ]),
+  )
+
+  await generateAnswersWithChatgptApiCompat(
+    'https://api.example.com/v1',
+    port,
+    'CurrentQ',
+    session,
+    'sk-test',
+  )
+
+  assert.equal(
+    port.postedMessages.some(
+      (message) => message.done === false && message.answer === 'Final content',
+    ),
+    true,
+  )
+  assert.deepEqual(session.conversationRecords.at(-1), {
+    question: 'CurrentQ',
+    answer: 'Final content',
+  })
+})
+
+test('generateAnswersWithGptCompletionApi builds completion prompt and appends answer', async (t) => {
+  t.mock.method(console, 'debug', () => {})
+  setStorage({
+    customOpenAiApiUrl: 'https://api.example.com',
+    maxConversationContextLength: 5,
+    maxResponseTokenLength: 300,
+    temperature: 0.5,
+  })
+
+  const session = {
+    modelName: 'gptApiInstruct',
+    conversationRecords: [{ question: 'FirstQ', answer: 'FirstA' }],
+    isRetry: false,
+  }
+  const port = createFakePort()
+
+  let capturedInput
+  let capturedInit
+  t.mock.method(globalThis, 'fetch', async (input, init) => {
+    capturedInput = input
+    capturedInit = init
+    return createMockSseResponse([
+      'data: {"choices":[{"text":"A"}]}\n\n',
+      'data: {"choices":[{"text":"B","finish_reason":"stop"}]}\n\n',
+    ])
+  })
+
+  await generateAnswersWithGptCompletionApi(port, 'NowQ', session, 'sk-completion')
+
+  assert.equal(capturedInput, 'https://api.example.com/v1/completions')
+  assert.equal(capturedInit.headers.Authorization, 'Bearer sk-completion')
+
+  const body = JSON.parse(capturedInit.body)
+  assert.equal(body.stream, true)
+  assert.equal(body.max_tokens, 300)
+  assert.equal(body.temperature, 0.5)
+  assert.equal(body.stop, '\nHuman')
+  assert.equal(body.prompt.includes('Human: FirstQ\nAI: FirstA\n'), true)
+  assert.equal(body.prompt.includes('Human: NowQ\nAI: '), true)
+
+  assert.equal(
+    port.postedMessages.some((message) => message.done === false && message.answer === 'AB'),
+    true,
+  )
+  assert.equal(
+    port.postedMessages.some((message) => message.done === true && message.session === session),
+    true,
+  )
+  assert.deepEqual(session.conversationRecords.at(-1), { question: 'NowQ', answer: 'AB' })
+})

--- a/tests/unit/services/apis/shared.test.mjs
+++ b/tests/unit/services/apis/shared.test.mjs
@@ -1,0 +1,78 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { pushRecord, setAbortController } from '../../../../src/services/apis/shared.mjs'
+import { createFakePort } from '../../helpers/port.mjs'
+
+test('pushRecord appends a new record in normal mode', () => {
+  const session = {
+    isRetry: false,
+    conversationRecords: [],
+  }
+
+  pushRecord(session, 'Q1', 'A1')
+
+  assert.deepEqual(session.conversationRecords, [{ question: 'Q1', answer: 'A1' }])
+})
+
+test('pushRecord overwrites last answer when retrying same question', () => {
+  const session = {
+    isRetry: true,
+    conversationRecords: [{ question: 'Q1', answer: 'Old' }],
+  }
+
+  pushRecord(session, 'Q1', 'New')
+
+  assert.equal(session.conversationRecords.length, 1)
+  assert.deepEqual(session.conversationRecords[0], { question: 'Q1', answer: 'New' })
+})
+
+test('pushRecord appends when retry question differs from last one', () => {
+  const session = {
+    isRetry: true,
+    conversationRecords: [{ question: 'Q1', answer: 'A1' }],
+  }
+
+  pushRecord(session, 'Q2', 'A2')
+
+  assert.equal(session.conversationRecords.length, 2)
+  assert.deepEqual(session.conversationRecords[1], { question: 'Q2', answer: 'A2' })
+})
+
+test('setAbortController aborts and cleans listeners on stop message', (t) => {
+  t.mock.method(console, 'debug', () => {})
+  const port = createFakePort()
+  let onStopCalled = 0
+
+  const { controller } = setAbortController(port, () => {
+    onStopCalled += 1
+  })
+
+  assert.equal(controller.signal.aborted, false)
+  assert.deepEqual(port.listenerCounts(), { onMessage: 1, onDisconnect: 1 })
+
+  port.emitMessage({ stop: true })
+
+  assert.equal(controller.signal.aborted, true)
+  assert.equal(onStopCalled, 1)
+  assert.deepEqual(port.postedMessages, [{ done: true }])
+  assert.deepEqual(port.listenerCounts(), { onMessage: 0, onDisconnect: 1 })
+})
+
+test('setAbortController aborts on disconnect and removes disconnect listener', (t) => {
+  t.mock.method(console, 'debug', () => {})
+  const port = createFakePort()
+  let onDisconnectCalled = 0
+
+  const { controller } = setAbortController(port, null, () => {
+    onDisconnectCalled += 1
+  })
+
+  assert.equal(controller.signal.aborted, false)
+  assert.deepEqual(port.listenerCounts(), { onMessage: 1, onDisconnect: 1 })
+
+  port.emitDisconnect()
+
+  assert.equal(controller.signal.aborted, true)
+  assert.equal(onDisconnectCalled, 1)
+  assert.deepEqual(port.listenerCounts(), { onMessage: 1, onDisconnect: 0 })
+})

--- a/tests/unit/setup/browser-shim.test.mjs
+++ b/tests/unit/setup/browser-shim.test.mjs
@@ -1,0 +1,151 @@
+import assert from 'node:assert/strict'
+import { beforeEach, test } from 'node:test'
+
+const waitForCallback = async (register) => {
+  await new Promise((resolve, reject) => {
+    const timeoutId = setTimeout(() => {
+      reject(new Error('Expected callback to be called'))
+    }, 100)
+
+    register(() => {
+      clearTimeout(timeoutId)
+      resolve()
+    })
+  })
+}
+
+beforeEach(() => {
+  globalThis.__TEST_BROWSER_SHIM__.clearStorage()
+})
+
+test('storage.local.get with object keys returns only requested keys and uses defaults', async () => {
+  globalThis.__TEST_BROWSER_SHIM__.replaceStorage({
+    requested: 'stored-value',
+    unrelated: 'should-not-be-returned',
+  })
+
+  const result = await globalThis.chrome.storage.local.get({
+    requested: 'default-value',
+    missing: 'default-missing',
+  })
+
+  assert.deepEqual(result, {
+    requested: 'stored-value',
+    missing: 'default-missing',
+  })
+  assert.equal('unrelated' in result, false)
+})
+
+test('storage.local.get with object defaults uses default for prototype-chain key names', async () => {
+  const result = await globalThis.chrome.storage.local.get({
+    toString: 'default-toString',
+    constructor: 'default-constructor',
+  })
+
+  assert.deepEqual(result, {
+    toString: 'default-toString',
+    constructor: 'default-constructor',
+  })
+})
+
+test('storage.local.get string key does not read prototype-chain properties', async () => {
+  const result = await globalThis.chrome.storage.local.get('toString')
+
+  assert.deepEqual(result, {})
+})
+
+test('storage.local.get array keys does not read prototype-chain properties', async () => {
+  const result = await globalThis.chrome.storage.local.get(['toString', 'constructor'])
+
+  assert.deepEqual(result, {})
+})
+
+test('storage.local.get prefers stored own property over object default', async () => {
+  globalThis.__TEST_BROWSER_SHIM__.replaceStorage({
+    toString: 'stored-toString',
+  })
+
+  const result = await globalThis.chrome.storage.local.get({
+    toString: 'default-toString',
+  })
+
+  assert.deepEqual(result, {
+    toString: 'stored-toString',
+  })
+})
+
+test('storage.local.get(null) returns all stored keys', async () => {
+  globalThis.__TEST_BROWSER_SHIM__.replaceStorage({
+    alpha: 1,
+    beta: 2,
+  })
+
+  const result = await globalThis.chrome.storage.local.get(null)
+
+  assert.deepEqual(result, {
+    alpha: 1,
+    beta: 2,
+  })
+})
+
+test('storage.local.get(undefined) returns all stored keys', async () => {
+  globalThis.__TEST_BROWSER_SHIM__.replaceStorage({
+    alpha: 1,
+    beta: 2,
+  })
+
+  const result = await globalThis.chrome.storage.local.get(undefined)
+
+  assert.deepEqual(result, {
+    alpha: 1,
+    beta: 2,
+  })
+})
+
+test('storage.local.get(null) keeps stored prototype-like key as data', async () => {
+  globalThis.__TEST_BROWSER_SHIM__.replaceStorage({
+    toString: 'stored-toString',
+  })
+
+  const result = await globalThis.chrome.storage.local.get(null)
+
+  assert.deepEqual(result, {
+    toString: 'stored-toString',
+  })
+})
+
+test('tabs.sendMessage supports callback as third argument (without options)', async () => {
+  await waitForCallback((done) => {
+    globalThis.chrome.tabs.sendMessage(1, { type: 'PING' }, done)
+  })
+})
+
+test('tabs.sendMessage supports callback as fourth argument (with options)', async () => {
+  await waitForCallback((done) => {
+    globalThis.chrome.tabs.sendMessage(1, { type: 'PING' }, { frameId: 0 }, done)
+  })
+})
+
+test('runtime.sendMessage supports callback as second argument (without options)', async () => {
+  await waitForCallback((done) => {
+    globalThis.chrome.runtime.sendMessage({ type: 'PING' }, done)
+  })
+})
+
+test('runtime.sendMessage supports callback as third argument (with options)', async () => {
+  await waitForCallback((done) => {
+    globalThis.chrome.runtime.sendMessage({ type: 'PING' }, { includeTlsChannelId: false }, done)
+  })
+})
+
+test('tabs.sendMessage returns a resolved promise when callback is omitted', async () => {
+  const result = await globalThis.chrome.tabs.sendMessage(1, { type: 'PING' })
+
+  assert.equal(result, undefined)
+})
+
+test('runtime.sendMessage returns a resolved promise when callback is omitted', async () => {
+  const result = await globalThis.chrome.runtime.sendMessage({ type: 'PING' })
+
+  assert.equal(result, undefined)
+})

--- a/tests/unit/utils/basic-guards.test.mjs
+++ b/tests/unit/utils/basic-guards.test.mjs
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { endsWithQuestionMark } from '../../../src/utils/ends-with-question-mark.mjs'
+import { getConversationPairs } from '../../../src/utils/get-conversation-pairs.mjs'
+import { parseFloatWithClamp } from '../../../src/utils/parse-float-with-clamp.mjs'
+import { parseIntWithClamp } from '../../../src/utils/parse-int-with-clamp.mjs'
+
+test('parseIntWithClamp handles NaN and boundaries', () => {
+  assert.equal(parseIntWithClamp('abc', 5, 1, 10), 5)
+  assert.equal(parseIntWithClamp('99', 5, 1, 10), 10)
+  assert.equal(parseIntWithClamp('-2', 5, 1, 10), 1)
+  assert.equal(parseIntWithClamp('7', 5, 1, 10), 7)
+})
+
+test('parseFloatWithClamp handles NaN and boundaries', () => {
+  assert.equal(parseFloatWithClamp('abc', 1.5, 0.5, 3.5), 1.5)
+  assert.equal(parseFloatWithClamp('8.8', 1.5, 0.5, 3.5), 3.5)
+  assert.equal(parseFloatWithClamp('0.1', 1.5, 0.5, 3.5), 0.5)
+  assert.equal(parseFloatWithClamp('2.2', 1.5, 0.5, 3.5), 2.2)
+})
+
+test('endsWithQuestionMark supports multiple question-mark styles', () => {
+  assert.equal(endsWithQuestionMark('How are you?'), true)
+  assert.equal(endsWithQuestionMark('你今天好嗎？'), true)
+  assert.equal(endsWithQuestionMark('هل أنت بخير؟'), true)
+  assert.equal(endsWithQuestionMark('reversed question⸮'), true)
+  assert.equal(endsWithQuestionMark('No punctuation'), false)
+})
+
+test('getConversationPairs returns completion prompt string when completion mode', () => {
+  const records = [
+    { question: 'Q1', answer: 'A1' },
+    { question: 'Q2', answer: 'A2' },
+  ]
+
+  const text = getConversationPairs(records, true)
+
+  assert.equal(text, 'Human: Q1\nAI: A1\nHuman: Q2\nAI: A2\n')
+})
+
+test('getConversationPairs returns chat messages when not completion mode', () => {
+  const records = [{ question: 'Q1', answer: 'A1' }]
+
+  const messages = getConversationPairs(records, false)
+
+  assert.deepEqual(messages, [
+    { role: 'user', content: 'Q1' },
+    { role: 'assistant', content: 'A1' },
+  ])
+})

--- a/tests/unit/utils/eventsource-parser.test.mjs
+++ b/tests/unit/utils/eventsource-parser.test.mjs
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { createParser } from '../../../src/utils/eventsource-parser.mjs'
+
+const encoder = new TextEncoder()
+
+const toBytes = (text) => encoder.encode(text)
+
+test('createParser parses basic SSE event data', () => {
+  const parsed = []
+  const parser = createParser((event) => parsed.push(event))
+
+  parser.feed(toBytes('data: hello world\n\n'))
+
+  assert.equal(parsed.length, 1)
+  assert.equal(parsed[0].type, 'event')
+  assert.equal(parsed[0].data, 'hello world')
+})
+
+test('createParser parses retry, event metadata, and multiline data', () => {
+  const parsed = []
+  const parser = createParser((event) => parsed.push(event))
+
+  parser.feed(toBytes('retry: 1500\n'))
+  parser.feed(
+    toBytes('event: update\nid: msg-1\ndata: part-1\ndata: part-2\nmeta: {"source":"test"}\n\n'),
+  )
+
+  assert.equal(parsed.length, 2)
+  assert.deepEqual(parsed[0], {
+    type: 'reconnect-interval',
+    value: 1500,
+  })
+
+  assert.equal(parsed[1].type, 'event')
+  assert.equal(parsed[1].event, 'update')
+  assert.equal(parsed[1].id, 'msg-1')
+  assert.equal(parsed[1].data, 'part-1\npart-2')
+  assert.deepEqual(parsed[1].extra, [{ meta: { source: 'test' } }])
+})
+
+test('createParser supports chunked input boundaries', () => {
+  const parsed = []
+  const parser = createParser((event) => parsed.push(event))
+
+  parser.feed(toBytes('data: par'))
+  parser.feed(toBytes('tial message'))
+  parser.feed(toBytes('\n\n'))
+
+  assert.equal(parsed.length, 1)
+  assert.equal(parsed[0].data, 'partial message')
+})
+
+test('createParser ignores UTF-8 BOM in the first chunk', () => {
+  const parsed = []
+  const parser = createParser((event) => parsed.push(event))
+
+  const withBom = new Uint8Array([239, 187, 191, ...toBytes('data: bom\n\n')])
+  parser.feed(withBom)
+
+  assert.equal(parsed.length, 1)
+  assert.equal(parsed[0].data, 'bom')
+})

--- a/tests/unit/utils/fetch-sse.test.mjs
+++ b/tests/unit/utils/fetch-sse.test.mjs
@@ -1,0 +1,114 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { fetchSSE } from '../../../src/utils/fetch-sse.mjs'
+import { createMockSseResponse } from '../helpers/sse-response.mjs'
+
+test('fetchSSE streams SSE chunks and calls lifecycle callbacks', async (t) => {
+  t.mock.method(console, 'debug', () => {})
+  const starts = []
+  const messages = []
+  const errors = []
+  let endCount = 0
+
+  t.mock.method(globalThis, 'fetch', async () =>
+    createMockSseResponse(['data: {"delta":"A"}\n\n', 'data: [DONE]\n\n']),
+  )
+
+  await fetchSSE('https://example.com/sse', {
+    method: 'POST',
+    onStart: async (chunkText) => {
+      starts.push(chunkText)
+    },
+    onMessage: (message) => {
+      messages.push(message)
+    },
+    onEnd: async () => {
+      endCount += 1
+    },
+    onError: async (error) => {
+      errors.push(error)
+    },
+  })
+
+  assert.equal(starts.length, 1)
+  assert.equal(starts[0], 'data: {"delta":"A"}\n\n')
+  assert.deepEqual(messages, ['{"delta":"A"}', '[DONE]'])
+  assert.equal(endCount, 1)
+  assert.equal(errors.length, 0)
+})
+
+test('fetchSSE converts a plain JSON first chunk into fake SSE data', async (t) => {
+  t.mock.method(console, 'debug', () => {})
+  const messages = []
+  let startedWith = ''
+  let endCount = 0
+
+  t.mock.method(globalThis, 'fetch', async () => createMockSseResponse(['{"answer":"ok"}']))
+
+  await fetchSSE('https://example.com/json', {
+    onStart: async (chunkText) => {
+      startedWith = chunkText
+    },
+    onMessage: (message) => {
+      messages.push(message)
+    },
+    onEnd: async () => {
+      endCount += 1
+    },
+    onError: async () => {},
+  })
+
+  assert.equal(startedWith, '{"answer":"ok"}')
+  assert.deepEqual(messages, ['{"answer":"ok"}', '[DONE]'])
+  assert.equal(endCount, 1)
+})
+
+test('fetchSSE forwards non-ok responses to onError', async (t) => {
+  t.mock.method(console, 'debug', () => {})
+  const errors = []
+  let endCalled = false
+
+  t.mock.method(globalThis, 'fetch', async () =>
+    createMockSseResponse([], {
+      ok: false,
+      status: 503,
+      statusText: 'Service Unavailable',
+    }),
+  )
+
+  await fetchSSE('https://example.com/error', {
+    onStart: async () => {},
+    onMessage: () => {},
+    onEnd: async () => {
+      endCalled = true
+    },
+    onError: async (error) => {
+      errors.push(error)
+    },
+  })
+
+  assert.equal(errors.length, 1)
+  assert.equal(errors[0].status, 503)
+  assert.equal(endCalled, false)
+})
+
+test('fetchSSE forwards fetch rejection errors to onError', async (t) => {
+  t.mock.method(console, 'debug', () => {})
+  const errors = []
+
+  t.mock.method(globalThis, 'fetch', async () => {
+    throw new Error('network down')
+  })
+
+  await fetchSSE('https://example.com/reject', {
+    onStart: async () => {},
+    onMessage: () => {},
+    onEnd: async () => {},
+    onError: async (error) => {
+      errors.push(error)
+    },
+  })
+
+  assert.equal(errors.length, 1)
+  assert.equal(errors[0].message, 'network down')
+})

--- a/tests/unit/utils/model-name-convert.test.mjs
+++ b/tests/unit/utils/model-name-convert.test.mjs
@@ -1,0 +1,105 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import {
+  apiModeToModelName,
+  getApiModesFromConfig,
+  isUsingModelName,
+  modelNameToApiMode,
+} from '../../../src/utils/model-name-convert.mjs'
+
+test('modelNameToApiMode and apiModeToModelName round-trip custom model names', () => {
+  const modelName = 'bingFree4-fast'
+  const apiMode = modelNameToApiMode(modelName)
+
+  assert.equal(apiMode.groupName, 'bingWebModelKeys')
+  assert.equal(apiMode.itemName, 'bingFree4')
+  assert.equal(apiMode.isCustom, true)
+  assert.equal(apiMode.customName, 'fast')
+  assert.equal(apiModeToModelName(apiMode), modelName)
+})
+
+test('apiModeToModelName uses groupName prefix for AlwaysCustomGroups', () => {
+  const apiMode = {
+    groupName: 'azureOpenAiApiModelKeys',
+    itemName: 'azureOpenAi',
+    isCustom: true,
+    customName: 'deployment-a',
+    customUrl: '',
+    apiKey: '',
+    active: true,
+  }
+
+  assert.equal(apiModeToModelName(apiMode), 'azureOpenAiApiModelKeys-deployment-a')
+})
+
+test('getApiModesFromConfig merges active and custom API modes correctly', () => {
+  const activeCustomMode = {
+    groupName: 'bingWebModelKeys',
+    itemName: 'bingFree4',
+    isCustom: true,
+    customName: 'fast',
+    customUrl: '',
+    apiKey: '',
+    active: true,
+  }
+
+  const inactiveCustomMode = {
+    groupName: 'bingWebModelKeys',
+    itemName: 'bingFreeSydney',
+    isCustom: true,
+    customName: 'slow',
+    customUrl: '',
+    apiKey: '',
+    active: false,
+  }
+
+  const config = {
+    activeApiModes: ['chatgptFree35', 'customModel', 'azureOpenAi'],
+    customApiModes: [activeCustomMode, inactiveCustomMode],
+    azureDeploymentName: 'deploy-a',
+    ollamaModelName: 'llama4',
+  }
+
+  const onlyActive = getApiModesFromConfig(config, true)
+  const allModes = getApiModesFromConfig(config, false)
+
+  assert.equal(
+    onlyActive.some((mode) => mode.itemName === 'chatgptFree35'),
+    true,
+  )
+  assert.equal(
+    onlyActive.some(
+      (mode) => mode.groupName === 'azureOpenAiApiModelKeys' && mode.customName === 'deploy-a',
+    ),
+    true,
+  )
+  assert.equal(
+    onlyActive.some((mode) => mode.itemName === 'bingFree4' && mode.customName === 'fast'),
+    true,
+  )
+  assert.equal(
+    onlyActive.some((mode) => mode.itemName === 'bingFreeSydney' && mode.customName === 'slow'),
+    false,
+  )
+
+  assert.equal(
+    allModes.some((mode) => mode.itemName === 'bingFreeSydney' && mode.customName === 'slow'),
+    true,
+  )
+})
+
+test('isUsingModelName matches base model for custom model names', () => {
+  assert.equal(isUsingModelName('bingFree4', { modelName: 'bingFree4-fast' }), true)
+  assert.equal(isUsingModelName('claude2WebFree', { modelName: 'chatgptFree35' }), false)
+
+  const apiMode = {
+    groupName: 'bingWebModelKeys',
+    itemName: 'bingFree4',
+    isCustom: true,
+    customName: 'fast',
+    customUrl: '',
+    apiKey: '',
+    active: true,
+  }
+  assert.equal(isUsingModelName('bingFree4', { apiMode }), true)
+})


### PR DESCRIPTION
### **User description**
Add `test` to package scripts and map it to `node --test`.

This creates a standard npm entrypoint for Node's built-in test runner so local and automation workflows can reference `npm run test` without hard-coding the Node CLI command.


___

### **PR Type**
Enhancement


___

### **Description**
- Add `test` npm script mapped to `node --test`

- Standardizes test execution via npm for local and CI workflows


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["package.json scripts"] -- "add test entry" --> B["test: node --test"]
  B -- "enables" --> C["npm run test command"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Add test script to npm scripts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

package.json

<ul><li>Added <code>"test": "node --test"</code> to the scripts section<br> <li> Provides standard npm entrypoint for Node's built-in test runner<br> <li> Allows CI/CD and local workflows to use <code>npm run test</code> consistently</ul>


</details>


  </td>
  <td><a href="https://github.com/ChatGPTBox-dev/chatGPTBox/pull/924/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a test script to enable running the project's automated test suite locally and in CI.

* **Tests**
  * Introduced a browser API shim and multiple test helpers to better simulate runtime behavior.
  * Added extensive unit tests covering API compatibility, streaming/SSE behavior, messaging, utilities, and model-name logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->