### PR TITLE
Add and refine high-value Node unit tests for core guards

### DIFF
--- a/tests/unit/config/config-predicates.test.mjs
+++ b/tests/unit/config/config-predicates.test.mjs
@@ -1,0 +1,87 @@
+import assert from 'node:assert/strict'
+import { afterEach, test } from 'node:test'
+import {
+  getNavigatorLanguage,
+  isUsingBingWebModel,
+  isUsingChatgptApiModel,
+  isUsingCustomModel,
+  isUsingMultiModeModel,
+  isUsingOpenAiApiModel,
+} from '../../../src/config/index.mjs'
+
+const originalNavigatorDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'navigator')
+
+const restoreNavigator = () => {
+  if (originalNavigatorDescriptor) {
+    Object.defineProperty(globalThis, 'navigator', originalNavigatorDescriptor)
+  } else {
+    delete globalThis.navigator
+  }
+}
+
+const setNavigatorLanguage = (language) => {
+  Object.defineProperty(globalThis, 'navigator', {
+    value: { language },
+    configurable: true,
+  })
+}
+
+afterEach(() => {
+  restoreNavigator()
+})
+
+test('getNavigatorLanguage returns zhHant for zh-TW style locales', () => {
+  setNavigatorLanguage('zh-TW')
+  assert.equal(getNavigatorLanguage(), 'zhHant')
+})
+
+test('getNavigatorLanguage returns first two letters for non-zhHant locales', () => {
+  setNavigatorLanguage('en-US')
+  assert.equal(getNavigatorLanguage(), 'en')
+})
+
+test('getNavigatorLanguage normalizes mixed-case zh-TW locale to zhHant', () => {
+  setNavigatorLanguage('ZH-TW')
+  assert.equal(getNavigatorLanguage(), 'zhHant')
+})
+
+test('getNavigatorLanguage treats zh-Hant locale as zhHant', () => {
+  setNavigatorLanguage('zh-Hant')
+  assert.equal(getNavigatorLanguage(), 'zhHant')
+})
+
+test('isUsingChatgptApiModel detects chatgpt API models and excludes custom model', () => {
+  assert.equal(isUsingChatgptApiModel({ modelName: 'chatgptApi4oMini' }), true)
+  assert.equal(isUsingChatgptApiModel({ modelName: 'customModel' }), false)
+})
+
+test('isUsingOpenAiApiModel accepts both chat and completion API model groups', () => {
+  assert.equal(isUsingOpenAiApiModel({ modelName: 'chatgptApi4oMini' }), true)
+  assert.equal(isUsingOpenAiApiModel({ modelName: 'gptApiInstruct' }), true)
+})
+
+test('isUsingOpenAiApiModel excludes custom model', () => {
+  assert.equal(isUsingOpenAiApiModel({ modelName: 'customModel' }), false)
+})
+
+test('isUsingCustomModel works with modelName and apiMode forms', () => {
+  assert.equal(isUsingCustomModel({ modelName: 'customModel' }), true)
+
+  const apiMode = {
+    groupName: 'customApiModelKeys',
+    itemName: 'customModel',
+    isCustom: true,
+    customName: 'my-custom-model',
+    customUrl: '',
+    apiKey: '',
+    active: true,
+  }
+  assert.equal(isUsingCustomModel({ apiMode }), true)
+})
+
+test('isUsingMultiModeModel currently follows Bing web group behavior', () => {
+  assert.equal(isUsingBingWebModel({ modelName: 'bingFree4' }), true)
+  assert.equal(isUsingMultiModeModel({ modelName: 'bingFree4' }), true)
+  assert.equal(isUsingBingWebModel({ modelName: 'chatgptFree35' }), false)
+  assert.equal(isUsingMultiModeModel({ modelName: 'chatgptFree35' }), false)
+})

--- a/tests/unit/config/user-config.test.mjs
+++ b/tests/unit/config/user-config.test.mjs
@@ -1,0 +1,90 @@
+import assert from 'node:assert/strict'
+import { beforeEach, test } from 'node:test'
+import { clearOldAccessToken, getUserConfig, setAccessToken } from '../../../src/config/index.mjs'
+
+const THIRTY_DAYS_MS = 30 * 24 * 3600 * 1000
+
+beforeEach(() => {
+  globalThis.__TEST_BROWSER_SHIM__.clearStorage()
+})
+
+test('getUserConfig migrates legacy chat.openai.com URL to chatgpt.com', async () => {
+  globalThis.__TEST_BROWSER_SHIM__.replaceStorage({
+    customChatGptWebApiUrl: 'https://chat.openai.com',
+  })
+
+  const config = await getUserConfig()
+
+  assert.equal(config.customChatGptWebApiUrl, 'https://chatgpt.com')
+})
+
+test('getUserConfig keeps modern chatgpt.com URL unchanged', async () => {
+  globalThis.__TEST_BROWSER_SHIM__.replaceStorage({
+    customChatGptWebApiUrl: 'https://chatgpt.com',
+  })
+
+  const config = await getUserConfig()
+
+  assert.equal(config.customChatGptWebApiUrl, 'https://chatgpt.com')
+})
+
+test('clearOldAccessToken clears expired token older than 30 days', async (t) => {
+  const now = 1_700_000_000_000
+  t.mock.method(Date, 'now', () => now)
+
+  globalThis.__TEST_BROWSER_SHIM__.replaceStorage({
+    accessToken: 'stale-token',
+    tokenSavedOn: now - THIRTY_DAYS_MS - 1_000,
+  })
+
+  await clearOldAccessToken()
+
+  const storage = globalThis.__TEST_BROWSER_SHIM__.getStorage()
+  assert.equal(storage.accessToken, '')
+  // tokenSavedOn write behavior is covered in the dedicated setAccessToken test below.
+})
+
+test('setAccessToken updates tokenSavedOn to Date.now', async (t) => {
+  const now = 1_700_000_000_000
+  t.mock.method(Date, 'now', () => now)
+
+  await setAccessToken('new-token')
+
+  const storage = globalThis.__TEST_BROWSER_SHIM__.getStorage()
+  assert.equal(storage.accessToken, 'new-token')
+  assert.equal(storage.tokenSavedOn, now)
+})
+
+test('clearOldAccessToken keeps recent token within 30 days', async (t) => {
+  const now = 1_700_000_000_000
+  t.mock.method(Date, 'now', () => now)
+  const recentSavedOn = now - THIRTY_DAYS_MS + 1_000
+
+  globalThis.__TEST_BROWSER_SHIM__.replaceStorage({
+    accessToken: 'fresh-token',
+    tokenSavedOn: recentSavedOn,
+  })
+
+  await clearOldAccessToken()
+
+  const storage = globalThis.__TEST_BROWSER_SHIM__.getStorage()
+  assert.equal(storage.accessToken, 'fresh-token')
+  assert.equal(storage.tokenSavedOn, recentSavedOn)
+})
+
+test('clearOldAccessToken keeps token when exactly 30 days old', async (t) => {
+  const now = 1_700_000_000_000
+  t.mock.method(Date, 'now', () => now)
+  const savedOn = now - THIRTY_DAYS_MS
+
+  globalThis.__TEST_BROWSER_SHIM__.replaceStorage({
+    accessToken: 'boundary-token',
+    tokenSavedOn: savedOn,
+  })
+
+  await clearOldAccessToken()
+
+  const storage = globalThis.__TEST_BROWSER_SHIM__.getStorage()
+  assert.equal(storage.accessToken, 'boundary-token')
+  assert.equal(storage.tokenSavedOn, savedOn)
+})

--- a/tests/unit/services/handle-port-error.test.mjs
+++ b/tests/unit/services/handle-port-error.test.mjs
@@ -1,0 +1,160 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { t as translate } from 'i18next'
+import { handlePortError } from '../../../src/services/wrappers.mjs'
+import { createFakePort } from '../helpers/port.mjs'
+
+test('handlePortError reports exceeded maximum context length', (t) => {
+  t.mock.method(console, 'error', () => {})
+  const port = createFakePort()
+  const message = 'maximum context length is 4096 tokens'
+
+  handlePortError({ modelName: 'chatgptApi4oMini' }, port, {
+    message,
+  })
+
+  assert.equal(port.postedMessages.length, 1)
+  assert.equal(port.postedMessages[0].error.includes(message), true)
+  assert.notEqual(port.postedMessages[0].error, message)
+})
+
+test('handlePortError treats "message you submitted was too long" as context-length error', (t) => {
+  t.mock.method(console, 'error', () => {})
+  const port = createFakePort()
+  const message = 'message you submitted was too long for this model'
+
+  handlePortError({ modelName: 'chatgptApi4oMini' }, port, {
+    message,
+  })
+
+  assert.equal(port.postedMessages.length, 1)
+  assert.equal(port.postedMessages[0].error.includes(message), true)
+  assert.notEqual(port.postedMessages[0].error, message)
+})
+
+test('handlePortError reports exceeded quota messages', (t) => {
+  t.mock.method(console, 'error', () => {})
+  const port = createFakePort()
+  const quotaMessage = 'You exceeded your current quota.'
+
+  handlePortError({ modelName: 'chatgptApi4oMini' }, port, {
+    message: quotaMessage,
+  })
+
+  assert.equal(port.postedMessages.length, 1)
+  assert.equal(port.postedMessages[0].error.includes(quotaMessage), true)
+  assert.notEqual(port.postedMessages[0].error, quotaMessage)
+})
+
+test('handlePortError reports rate-limit messages', (t) => {
+  t.mock.method(console, 'error', () => {})
+  const port = createFakePort()
+  const rateMessage = 'Rate limit reached for requests'
+
+  handlePortError({ modelName: 'chatgptApi4oMini' }, port, {
+    message: rateMessage,
+  })
+
+  assert.equal(port.postedMessages.length, 1)
+  assert.equal(port.postedMessages[0].error.includes(rateMessage), true)
+  assert.notEqual(port.postedMessages[0].error, rateMessage)
+})
+
+test('handlePortError reports Bing captcha challenge message', (t) => {
+  t.mock.method(console, 'error', () => {})
+  const port = createFakePort()
+  const message = 'CAPTCHA challenge required'
+
+  handlePortError({ modelName: 'bingFree4' }, port, {
+    message,
+  })
+
+  assert.equal(port.postedMessages.length, 1)
+  assert.equal(port.postedMessages[0].error.includes(message), true)
+  assert.notEqual(port.postedMessages[0].error, message)
+})
+
+test('handlePortError maps expired authentication token to UNAUTHORIZED', (t) => {
+  t.mock.method(console, 'error', () => {})
+  const port = createFakePort()
+
+  handlePortError({ modelName: 'chatgptApi4oMini' }, port, {
+    message: 'authentication token has expired',
+  })
+
+  assert.equal(port.postedMessages.length, 1)
+  assert.equal(port.postedMessages[0].error, 'UNAUTHORIZED')
+})
+
+test('handlePortError ignores aborted errors', (t) => {
+  t.mock.method(console, 'error', () => {})
+  const port = createFakePort()
+
+  handlePortError({ modelName: 'chatgptApi4oMini' }, port, {
+    message: 'request aborted by user',
+  })
+
+  assert.deepEqual(port.postedMessages, [])
+})
+
+test('handlePortError reports Claude web authorization hint', (t) => {
+  t.mock.method(console, 'error', () => {})
+  const port = createFakePort()
+
+  handlePortError({ modelName: 'claude2WebFree' }, port, {
+    message: 'Invalid authorization',
+  })
+
+  assert.equal(port.postedMessages.length, 1)
+  assert.equal(
+    port.postedMessages[0].error,
+    translate('Please login at https://claude.ai first, and then click the retry button'),
+  )
+  assert.notEqual(port.postedMessages[0].error, 'Invalid authorization')
+})
+
+test('handlePortError reports Bing login hint for turing parse-response failures', (t) => {
+  t.mock.method(console, 'error', () => {})
+  const port = createFakePort()
+  const message = '/turing/conversation/create: failed to parse response body.'
+
+  handlePortError({ modelName: 'bingFree4' }, port, { message })
+
+  assert.equal(port.postedMessages.length, 1)
+  assert.equal(port.postedMessages[0].error, translate('Please login at https://bing.com first'))
+  assert.notEqual(port.postedMessages[0].error, message)
+})
+
+test('handlePortError reports Bing login hint when trusted error has no message', (t) => {
+  t.mock.method(console, 'error', () => {})
+  const port = createFakePort()
+  const err = { isTrusted: true }
+
+  handlePortError({ modelName: 'bingFree4' }, port, err)
+
+  assert.equal(port.postedMessages.length, 1)
+  assert.equal(port.postedMessages[0].error, translate('Please login at https://bing.com first'))
+  assert.notEqual(port.postedMessages[0].error, JSON.stringify(err))
+})
+
+test('handlePortError forwards unknown message errors as-is', (t) => {
+  t.mock.method(console, 'error', () => {})
+  const port = createFakePort()
+  const message = 'unknown upstream error'
+
+  handlePortError({ modelName: 'chatgptApi4oMini' }, port, { message })
+
+  assert.equal(port.postedMessages.length, 1)
+  assert.equal(port.postedMessages[0].error, message)
+})
+
+test('handlePortError stringifies non-message errors for non-Bing models', (t) => {
+  t.mock.method(console, 'error', () => {})
+  const port = createFakePort()
+  const err = { code: 'E_UNKNOWN', detail: 'network disconnected' }
+
+  handlePortError({ modelName: 'chatgptApi4oMini' }, port, err)
+
+  assert.equal(port.postedMessages.length, 1)
+  assert.equal(port.postedMessages[0].error, JSON.stringify(err))
+})

--- a/tests/unit/utils/basic-guards.test.mjs
+++ b/tests/unit/utils/basic-guards.test.mjs
@@ -5,11 +5,36 @@ import { getConversationPairs } from '../../../src/utils/get-conversation-pairs.
 import { parseFloatWithClamp } from '../../../src/utils/parse-float-with-clamp.mjs'
 import { parseIntWithClamp } from '../../../src/utils/parse-int-with-clamp.mjs'
 
-test('parseIntWithClamp handles NaN and boundaries', () => {
-  assert.equal(parseIntWithClamp('abc', 5, 1, 10), 5)
-  assert.equal(parseIntWithClamp('99', 5, 1, 10), 10)
-  assert.equal(parseIntWithClamp('-2', 5, 1, 10), 1)
-  assert.equal(parseIntWithClamp('7', 5, 1, 10), 7)
+const PARSE_INT_DEFAULT = 5
+const PARSE_INT_MIN = 1
+const PARSE_INT_MAX = 10
+
+const parseIntWithDefaultRange = (value) =>
+  parseIntWithClamp(value, PARSE_INT_DEFAULT, PARSE_INT_MIN, PARSE_INT_MAX)
+
+test('parseIntWithClamp returns default value for non-numeric input', () => {
+  assert.equal(parseIntWithDefaultRange('abc'), PARSE_INT_DEFAULT)
+})
+
+test('parseIntWithClamp clamps values outside the default range', () => {
+  assert.equal(parseIntWithDefaultRange('99'), PARSE_INT_MAX)
+  assert.equal(parseIntWithDefaultRange('-2'), PARSE_INT_MIN)
+})
+
+test('parseIntWithClamp keeps in-range integer values unchanged', () => {
+  assert.equal(parseIntWithDefaultRange('7'), 7)
+})
+
+test('parseIntWithClamp truncates decimal strings before clamping', () => {
+  assert.equal(parseIntWithClamp('42.99', PARSE_INT_DEFAULT, 1, 100), 42)
+  assert.equal(parseIntWithClamp('-42.99', PARSE_INT_DEFAULT, -100, -1), -42)
+})
+
+test('parseIntWithClamp returns the fixed bound when min equals max', () => {
+  const fixedBound = 50
+
+  assert.equal(parseIntWithClamp('40', PARSE_INT_DEFAULT, fixedBound, fixedBound), fixedBound)
+  assert.equal(parseIntWithClamp('60', PARSE_INT_DEFAULT, fixedBound, fixedBound), fixedBound)
 })
 
 test('parseFloatWithClamp handles NaN and boundaries', () => {
@@ -46,5 +71,34 @@ test('getConversationPairs returns chat messages when not completion mode', () =
   assert.deepEqual(messages, [
     { role: 'user', content: 'Q1' },
     { role: 'assistant', content: 'A1' },
+  ])
+})
+
+test('getConversationPairs returns empty outputs for empty records', () => {
+  assert.equal(getConversationPairs([], true), '')
+  assert.deepEqual(getConversationPairs([], false), [])
+})
+
+test('getConversationPairs defaults to chat-message output when isCompletion is omitted', () => {
+  const records = [{ question: 'Q1', answer: 'A1' }]
+
+  assert.deepEqual(getConversationPairs(records), [
+    { role: 'user', content: 'Q1' },
+    { role: 'assistant', content: 'A1' },
+  ])
+})
+
+test('getConversationPairs keeps empty question and answer strings unchanged', () => {
+  const records = [
+    { question: '', answer: 'A1' },
+    { question: 'Q2', answer: '' },
+  ]
+
+  assert.equal(getConversationPairs(records, true), 'Human: \nAI: A1\nHuman: Q2\nAI: \n')
+  assert.deepEqual(getConversationPairs(records, false), [
+    { role: 'user', content: '' },
+    { role: 'assistant', content: 'A1' },
+    { role: 'user', content: 'Q2' },
+    { role: 'assistant', content: '' },
   ])
 })

--- a/tests/unit/utils/browser-detection.test.mjs
+++ b/tests/unit/utils/browser-detection.test.mjs
@@ -1,0 +1,120 @@
+import assert from 'node:assert/strict'
+import { afterEach, test } from 'node:test'
+import { isEdge } from '../../../src/utils/is-edge.mjs'
+import { isFirefox } from '../../../src/utils/is-firefox.mjs'
+import { isMobile } from '../../../src/utils/is-mobile.mjs'
+import { isSafari } from '../../../src/utils/is-safari.mjs'
+
+const originalNavigatorDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'navigator')
+const originalWindowDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'window')
+
+const restoreGlobal = (name, descriptor) => {
+  if (descriptor) {
+    Object.defineProperty(globalThis, name, descriptor)
+  } else {
+    delete globalThis[name]
+  }
+}
+
+const setBrowserState = ({ userAgent, vendor, userAgentData, opera } = {}) => {
+  const navigatorState = {}
+  if (userAgent !== undefined) navigatorState.userAgent = userAgent
+  if (vendor !== undefined) navigatorState.vendor = vendor
+  if (userAgentData !== undefined) navigatorState.userAgentData = userAgentData
+
+  Object.defineProperty(globalThis, 'navigator', {
+    value: navigatorState,
+    configurable: true,
+  })
+
+  const windowState = {}
+  if (opera !== undefined) windowState.opera = opera
+  Object.defineProperty(globalThis, 'window', {
+    value: windowState,
+    configurable: true,
+  })
+}
+
+afterEach(() => {
+  restoreGlobal('navigator', originalNavigatorDescriptor)
+  restoreGlobal('window', originalWindowDescriptor)
+})
+
+test('isMobile prioritizes navigator.userAgentData.mobile when available', () => {
+  setBrowserState({
+    userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)',
+    userAgentData: { mobile: true },
+  })
+
+  assert.equal(isMobile(), true)
+})
+
+test('isMobile returns false for desktop-like user agent when userAgentData is unavailable', () => {
+  setBrowserState({
+    userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
+  })
+
+  assert.equal(isMobile(), false)
+})
+
+test('isMobile detects mobile from iPhone user agent', () => {
+  setBrowserState({
+    userAgent:
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605.1.15 Mobile/15E148',
+  })
+
+  assert.equal(isMobile(), true)
+})
+
+test('isMobile falls back to window.opera when userAgent and vendor are missing', () => {
+  setBrowserState({
+    userAgent: undefined,
+    vendor: undefined,
+    opera: 'Opera Mini/36.2.2254/191.249',
+  })
+
+  assert.equal(isMobile(), true)
+})
+
+test('isEdge detects Edge user agent', () => {
+  setBrowserState({
+    userAgent:
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/120.0.0.0 EdG/120.0.0.0',
+  })
+
+  assert.equal(isEdge(), true)
+})
+
+test('isEdge excludes non-Edge user agent', () => {
+  setBrowserState({
+    userAgent:
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/120.0.0.0 Safari/537.36',
+  })
+
+  assert.equal(isEdge(), false)
+})
+
+test('isFirefox detects Firefox user agent', () => {
+  setBrowserState({
+    userAgent: 'Mozilla/5.0 (X11; Linux x86_64; rv:123.0) Gecko/20100101 Firefox/123.0',
+  })
+
+  assert.equal(isFirefox(), true)
+})
+
+test('isFirefox excludes non-Firefox user agent', () => {
+  setBrowserState({
+    userAgent:
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 Version/17.2 Safari/605.1.15',
+  })
+
+  assert.equal(isFirefox(), false)
+})
+
+test('isSafari requires exact Apple vendor match', () => {
+  setBrowserState({ vendor: 'Apple Computer, Inc.' })
+  assert.equal(isSafari(), true)
+
+  setBrowserState({ vendor: 'Google Inc.' })
+  assert.equal(isSafari(), false)
+})

--- a/tests/unit/utils/get-client-position.test.mjs
+++ b/tests/unit/utils/get-client-position.test.mjs
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { getClientPosition } from '../../../src/utils/get-client-position.mjs'
+
+test('getClientPosition returns x/y from bounding client rect', () => {
+  const element = {
+    getBoundingClientRect() {
+      return { left: 50, top: 120 }
+    },
+  }
+
+  assert.deepEqual(getClientPosition(element), { x: 50, y: 120 })
+})
+
+test('getClientPosition supports negative coordinates', () => {
+  const element = {
+    getBoundingClientRect() {
+      return { left: -12, top: 8 }
+    },
+  }
+
+  assert.deepEqual(getClientPosition(element), { x: -12, y: 8 })
+})
+
+test('getClientPosition throws when element does not expose getBoundingClientRect', () => {
+  assert.throws(() => getClientPosition({}), TypeError)
+})
+
+test('getClientPosition throws when element is null', () => {
+  assert.throws(() => getClientPosition(null), TypeError)
+})
+
+test('getClientPosition throws when element is undefined', () => {
+  assert.throws(() => getClientPosition(undefined), TypeError)
+})

--- a/tests/unit/utils/set-element-position-in-viewport.test.mjs
+++ b/tests/unit/utils/set-element-position-in-viewport.test.mjs
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict'
+import { afterEach, test } from 'node:test'
+import { setElementPositionInViewport } from '../../../src/utils/set-element-position-in-viewport.mjs'
+
+const originalWindowDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'window')
+
+const restoreWindow = () => {
+  if (originalWindowDescriptor) {
+    Object.defineProperty(globalThis, 'window', originalWindowDescriptor)
+  } else {
+    delete globalThis.window
+  }
+}
+
+const setViewport = (innerWidth, innerHeight) => {
+  Object.defineProperty(globalThis, 'window', {
+    value: { innerWidth, innerHeight },
+    configurable: true,
+  })
+}
+
+const createElement = (offsetWidth, offsetHeight) => ({
+  offsetWidth,
+  offsetHeight,
+  style: {},
+})
+
+afterEach(() => {
+  restoreWindow()
+})
+
+test('setElementPositionInViewport keeps position within viewport bounds', () => {
+  setViewport(320, 200)
+  const element = createElement(80, 40)
+
+  const position = setElementPositionInViewport(element, 100, 60)
+
+  assert.deepEqual(position, { x: 100, y: 60 })
+  assert.equal(element.style.left, '100px')
+  assert.equal(element.style.top, '60px')
+})
+
+test('setElementPositionInViewport clamps negative coordinates to zero', () => {
+  setViewport(320, 200)
+  const element = createElement(80, 40)
+
+  const position = setElementPositionInViewport(element, -10, -20)
+
+  assert.deepEqual(position, { x: 0, y: 0 })
+  assert.equal(element.style.left, '0px')
+  assert.equal(element.style.top, '0px')
+})
+
+test('setElementPositionInViewport clamps overflow to max visible coordinates', () => {
+  setViewport(320, 200)
+  const element = createElement(80, 40)
+
+  const position = setElementPositionInViewport(element, 500, 300)
+
+  assert.deepEqual(position, { x: 240, y: 160 })
+  assert.equal(element.style.left, '240px')
+  assert.equal(element.style.top, '160px')
+})
+
+test('setElementPositionInViewport returns zero when element is larger than viewport', () => {
+  setViewport(100, 80)
+  const element = createElement(150, 120)
+
+  const position = setElementPositionInViewport(element, 20, 30)
+
+  assert.deepEqual(position, { x: 0, y: 0 })
+  assert.equal(element.style.left, '0px')
+  assert.equal(element.style.top, '0px')
+})


### PR DESCRIPTION
### **User description**

Expand Node unit coverage for config predicates, token-retention
boundaries, port-error handling, and utility guard edge cases.

Refine existing util tests so boundary intent is explicit and easier to
review, while preserving current runtime behavior.


___

### **PR Type**
Tests


___

### **Description**
- Add comprehensive unit tests for config predicates and user config

- Expand OpenAI API compatibility tests for token parameter handling

- Add port error handling tests covering multiple error scenarios

- Refine utility guard tests with explicit boundary and edge-case coverage

- Add browser detection and DOM utility tests with global state mocking


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Config Tests"] --> B["Test Suite"]
  C["API Compat Tests"] --> B
  D["Port Error Tests"] --> B
  E["Utility Guard Tests"] --> B
  F["Browser Detection Tests"] --> B
  B --> G["Expanded Coverage"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><details><summary>9 files</summary><table>
<tr>
  <td><strong>config-predicates.test.mjs</strong><dd><code>New tests for config predicate functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ChatGPTBox-dev/chatGPTBox/pull/929/files#diff-bfd96a829f986332e4c242ea5c5886ff9c5ad84ab73be32f216a19b957ccaad3">+87/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>user-config.test.mjs</strong><dd><code>New tests for user config and token retention</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ChatGPTBox-dev/chatGPTBox/pull/929/files#diff-cbde49bf6f1e352b984dbedd0e0a84566dc7fc9df868fd9a20ba9370135902b9">+79/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>openai-api-compat.test.mjs</strong><dd><code>Tests for OpenAI gpt-5 token parameter handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ChatGPTBox-dev/chatGPTBox/pull/929/files#diff-8dc051f9fb1bd7b09842d13ba118b6457946a3cb46da6e94a516378e01695764">+204/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>shared.test.mjs</strong><dd><code>Tests for abort controller message filtering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ChatGPTBox-dev/chatGPTBox/pull/929/files#diff-a6b3f970c3913a1fc3d8b05deca3cf6a9f445f83e04c2d98b40e3b0d689af88f">+31/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>handle-port-error.test.mjs</strong><dd><code>New comprehensive port error handling tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ChatGPTBox-dev/chatGPTBox/pull/929/files#diff-d477250211bbf30e0e468b1d37fe75898156829d0203c1e16e558e3f2caaa6cb">+145/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>basic-guards.test.mjs</strong><dd><code>Refined parseIntWithClamp and getConversationPairs tests</code>&nbsp; </dd></td>
  <td><a href="https://github.com/ChatGPTBox-dev/chatGPTBox/pull/929/files#diff-a60a05ff4c19cdcfd25f4e038669bfe797be83091722e6390e7b555971fb0b4b">+59/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>browser-detection.test.mjs</strong><dd><code>New browser detection utility tests with mocking</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ChatGPTBox-dev/chatGPTBox/pull/929/files#diff-5248129e2635199c810e032ab33029d7bb28f9b417d776caadc6fa04ca7ce44b">+112/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>get-client-position.test.mjs</strong><dd><code>New DOM element position retrieval tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ChatGPTBox-dev/chatGPTBox/pull/929/files#diff-086645857b47575437c6c67b99891185c4d5c45a7743e42e1a7d8c4c86fd7d21">+35/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>set-element-position-in-viewport.test.mjs</strong><dd><code>New viewport position clamping tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ChatGPTBox-dev/chatGPTBox/pull/929/files#diff-9e665a394053e90232a5a614055164d301a771189e84f1a469d794b7c3017440">+74/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added broad unit tests for configuration checks, user settings and token retention, and API compatibility with newer model variants.
  * Added tests for error handling and port message mapping.
  * Added browser-detection and viewport/element-positioning tests to improve UI reliability across environments.
  * Added tests for abort/stop handling and core utility behaviors to strengthen stability and edge-case coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->