### PR TITLE
fix: correct casing for site adapter display names

### DIFF
--- a/src/popup/sections/SiteAdapters.jsx
+++ b/src/popup/sections/SiteAdapters.jsx
@@ -1,5 +1,20 @@
 import PropTypes from 'prop-types'
 
+const siteDisplayNames = {
+  bilibili: 'Bilibili',
+  github: 'GitHub',
+  gitlab: 'GitLab',
+  quora: 'Quora',
+  reddit: 'Reddit',
+  youtube: 'YouTube',
+  zhihu: 'Zhihu',
+  stackoverflow: 'Stack Overflow',
+  juejin: 'Juejin',
+  'mp.weixin.qq': 'WeChat MP',
+  followin: 'Followin',
+  arxiv: 'arXiv',
+}
+
 SiteAdapters.propTypes = {
   config: PropTypes.object.isRequired,
   updateConfig: PropTypes.func.isRequired,
@@ -20,7 +35,7 @@ export function SiteAdapters({ config, updateConfig }) {
               updateConfig({ activeSiteAdapters })
             }}
           />
-          {key}
+          {siteDisplayNames[key] || key}
         </label>
       ))}
     </>


### PR DESCRIPTION
### **User description**
This adds a display name mapping to the SiteAdapters component to show proper capitalization (e.g., 'GitHub' instead of 'github') while preserving internal config keys.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add display name mapping for site adapters with proper capitalization

- Replace raw config keys with user-friendly display names in UI

- Fallback to original key if display name not found


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Site adapter config keys<br/>github, youtube, etc."] -- "siteDisplayNames mapping" --> B["Display names<br/>GitHub, YouTube, etc."]
  B -- "render in UI" --> C["User-friendly labels"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SiteAdapters.jsx</strong><dd><code>Add display name mapping for site adapters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/popup/sections/SiteAdapters.jsx

<ul><li>Added <code>siteDisplayNames</code> object mapping 14 site adapter keys to properly <br>capitalized display names<br> <li> Updated render logic to use <code>siteDisplayNames[key] || key</code> for fallback <br>support<br> <li> Improves UI readability by showing 'GitHub' instead of 'github', <br>'YouTube' instead of 'youtube', etc.</ul>


</details>


  </td>
  <td><a href="https://github.com/ChatGPTBox-dev/chatGPTBox/pull/933/files#diff-0c4b9c1b582ebb62aceada4bba5e7acb59f386df56f9bd891f98d134b3f2ef69">+16/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Site adapter labels now display user-friendly names (e.g., "Bilibili" instead of "bilibili", "GitHub" instead of "github") for improved clarity and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->