### PR TITLE
test: expand unit test coverage across utils, APIs, and services

### DIFF
--- a/src/background/redact.mjs
+++ b/src/background/redact.mjs
@@ -1,0 +1,74 @@
+const SENSITIVE_KEYWORDS = [
+  'apikey', // Covers apiKey, customApiKey, claudeApiKey, etc.
+  'token', // Covers accessToken, refreshToken, etc.
+  'secret',
+  'password',
+  'kimimoonshotrefreshtoken',
+  'credential',
+  'jwt',
+  'session',
+]
+
+export function isPromptOrSelectionLikeKey(lowerKey) {
+  lowerKey = lowerKey.toLowerCase()
+  const normalizedKey = lowerKey.replace(/[^a-z0-9]/g, '')
+  return (
+    normalizedKey.endsWith('question') ||
+    normalizedKey.endsWith('prompt') ||
+    normalizedKey.endsWith('query') ||
+    normalizedKey === 'selection' ||
+    normalizedKey === 'selectiontext'
+  )
+}
+
+export function redactSensitiveFields(obj, recursionDepth = 0, maxDepth = 5, seen = new WeakSet()) {
+  if (recursionDepth > maxDepth) {
+    // Prevent infinite recursion on circular objects or excessively deep structures
+    return 'REDACTED_TOO_DEEP'
+  }
+  if (obj === null || typeof obj !== 'object') {
+    return obj
+  }
+
+  if (seen.has(obj)) {
+    return 'REDACTED_CIRCULAR_REFERENCE'
+  }
+  seen.add(obj)
+
+  if (Array.isArray(obj)) {
+    const redactedArray = []
+    for (let i = 0; i < obj.length; i++) {
+      const item = obj[i]
+      if (item !== null && typeof item === 'object') {
+        redactedArray[i] = redactSensitiveFields(item, recursionDepth + 1, maxDepth, seen)
+      } else {
+        redactedArray[i] = item
+      }
+    }
+    return redactedArray
+  }
+
+  const redactedObj = {}
+  for (const key in obj) {
+    if (Object.prototype.hasOwnProperty.call(obj, key)) {
+      const lowerKey = key.toLowerCase()
+      let isKeySensitive = isPromptOrSelectionLikeKey(lowerKey)
+      if (!isKeySensitive) {
+        for (const keyword of SENSITIVE_KEYWORDS) {
+          if (lowerKey.includes(keyword)) {
+            isKeySensitive = true
+            break
+          }
+        }
+      }
+      if (isKeySensitive) {
+        redactedObj[key] = 'REDACTED'
+      } else if (obj[key] !== null && typeof obj[key] === 'object') {
+        redactedObj[key] = redactSensitiveFields(obj[key], recursionDepth + 1, maxDepth, seen)
+      } else {
+        redactedObj[key] = obj[key]
+      }
+    }
+  }
+  return redactedObj
+}

--- a/src/services/apis/custom-api.mjs
+++ b/src/services/apis/custom-api.mjs
@@ -76,12 +76,12 @@ export async function generateAnswersWithCustomApi(
 
       if (data.response) answer = data.response
       else {
-        const delta = data.choices[0]?.delta?.content
-        const content = data.choices[0]?.message?.content
-        const text = data.choices[0]?.text
+        const delta = data.choices?.[0]?.delta?.content
+        const content = data.choices?.[0]?.message?.content
+        const text = data.choices?.[0]?.text
         if (delta !== undefined) {
           answer += delta
-        } else if (content) {
+        } else if (typeof content === 'string') {
           answer = content
         } else if (text) {
           answer += text
@@ -89,7 +89,7 @@ export async function generateAnswersWithCustomApi(
       }
       port.postMessage({ answer: answer, done: false, session: null })
 
-      if (data.choices[0]?.finish_reason) {
+      if (data.choices?.[0]?.finish_reason) {
         finish()
         return
       }

--- a/tests/setup/jsx-loader-hooks.mjs
+++ b/tests/setup/jsx-loader-hooks.mjs
@@ -1,0 +1,59 @@
+// ESM loader hooks that transform .mjs files containing JSX via esbuild
+// and provide CJS-to-ESM interop for packages that need it.
+// Register with: module.register('./tests/setup/jsx-loader-hooks.mjs', import.meta.url)
+import { readFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import { createRequire } from 'node:module'
+
+const JSX_RE = /<[A-Z][A-Za-z0-9]*[\s/>]/
+
+// CJS packages that need named-export re-exporting for ESM consumers.
+const CJS_REEXPORT = new Set(['countries-list'])
+
+export async function load(url, context, nextLoad) {
+  // Handle CJS packages that lack ESM named exports
+  for (const pkg of CJS_REEXPORT) {
+    if (url.includes(`/node_modules/${pkg}/`)) {
+      const require = createRequire(url)
+      const mod = require(pkg)
+      const IDENT_RE = /^[a-zA-Z_$][a-zA-Z0-9_$]*$/
+      const names = Object.keys(mod).filter((k) => k !== 'default' && k !== '__esModule')
+      const used = new Set()
+      const toSafe = (k) => {
+        let s = k.replace(/[^a-zA-Z0-9_$]/g, '_')
+        if (/^[0-9]/.test(s)) s = '_' + s
+        while (used.has(s)) s = '_' + s
+        used.add(s)
+        return s
+      }
+      const src = [
+        `import { createRequire as _cr } from 'node:module';`,
+        `const _req = _cr(${JSON.stringify(url)});`,
+        `const _mod = _req(${JSON.stringify(pkg)});`,
+        ...names.map((n) => {
+          const id = IDENT_RE.test(n) ? n : toSafe(n)
+          return `export const ${id} = _mod[${JSON.stringify(n)}];`
+        }),
+        `export default _mod;`,
+      ].join('\n')
+      return { shortCircuit: true, format: 'module', source: src }
+    }
+  }
+
+  // Transform source .mjs files that contain JSX
+  if (url.startsWith('file://') && url.endsWith('.mjs') && !url.includes('node_modules')) {
+    const filePath = fileURLToPath(url)
+    const source = await readFile(filePath, 'utf8')
+    if (JSX_RE.test(source)) {
+      const esbuild = await import('esbuild')
+      const result = await esbuild.transform(source, {
+        loader: 'jsx',
+        jsx: 'automatic',
+        jsxImportSource: 'preact',
+      })
+      return { shortCircuit: true, format: 'module', source: result.code }
+    }
+  }
+
+  return nextLoad(url, context)
+}

--- a/tests/unit/background/redact.test.mjs
+++ b/tests/unit/background/redact.test.mjs
@@ -1,0 +1,110 @@
+import assert from 'node:assert/strict'
+import { describe, test } from 'node:test'
+import {
+  redactSensitiveFields,
+  isPromptOrSelectionLikeKey,
+} from '../../../src/background/redact.mjs'
+
+describe('redactSensitiveFields', () => {
+  test('redacts keys containing sensitive keywords', () => {
+    const input = {
+      apiKey: 'sk-1234',
+      accessToken: 'tok-abc',
+      secret: 'shh',
+      password: 'hunter2',
+      credential: 'cred-value',
+      jwt: 'eyJ...',
+      session: 'sess-xyz',
+      kimimoonshotrefreshtoken: 'refresh-val',
+    }
+    const result = redactSensitiveFields(input)
+    for (const key of Object.keys(input)) {
+      assert.equal(result[key], 'REDACTED', `expected ${key} to be redacted`)
+    }
+  })
+
+  test('preserves non-sensitive keys', () => {
+    const input = { name: 'Alice', age: 30, enabled: true }
+    const result = redactSensitiveFields(input)
+    assert.deepEqual(result, { name: 'Alice', age: 30, enabled: true })
+  })
+
+  test('handles nested objects', () => {
+    const input = {
+      user: { name: 'Bob', apiKey: 'sk-nested' },
+      count: 5,
+    }
+    const result = redactSensitiveFields(input)
+    assert.equal(result.user.name, 'Bob')
+    assert.equal(result.user.apiKey, 'REDACTED')
+    assert.equal(result.count, 5)
+  })
+
+  test('handles arrays with mixed objects', () => {
+    const input = [{ name: 'a', token: 'tok1' }, 'plain-string', 42, { password: 'pw', safe: true }]
+    const result = redactSensitiveFields(input)
+    assert.ok(Array.isArray(result))
+    assert.equal(result[0].name, 'a')
+    assert.equal(result[0].token, 'REDACTED')
+    assert.equal(result[1], 'plain-string')
+    assert.equal(result[2], 42)
+    assert.equal(result[3].password, 'REDACTED')
+    assert.equal(result[3].safe, true)
+  })
+
+  test('respects maxDepth', () => {
+    const deep = { a: { b: { c: { d: 'value' } } } }
+    const result = redactSensitiveFields(deep, 0, 2)
+    assert.equal(result.a.b.c, 'REDACTED_TOO_DEEP')
+  })
+
+  test('handles null and primitive inputs', () => {
+    assert.equal(redactSensitiveFields(null), null)
+    assert.equal(redactSensitiveFields(42), 42)
+    assert.equal(redactSensitiveFields('hello'), 'hello')
+    assert.equal(redactSensitiveFields(undefined), undefined)
+  })
+
+  test('handles circular references', () => {
+    const obj = { name: 'root' }
+    obj.self = obj
+    const result = redactSensitiveFields(obj)
+    assert.equal(result.name, 'root')
+    assert.equal(result.self, 'REDACTED_CIRCULAR_REFERENCE')
+  })
+
+  test('redacts prompt/selection-like keys via isPromptOrSelectionLikeKey integration', () => {
+    const input = {
+      prompt: 'secret input',
+      userQuestion: 'what is X?',
+      selection: 'highlighted text',
+      name: 'safe',
+    }
+    const result = redactSensitiveFields(input)
+    assert.equal(result.prompt, 'REDACTED')
+    assert.equal(result.userQuestion, 'REDACTED')
+    assert.equal(result.selection, 'REDACTED')
+    assert.equal(result.name, 'safe')
+  })
+})
+
+describe('isPromptOrSelectionLikeKey', () => {
+  test('matches prompt/selection-related keys', () => {
+    assert.ok(isPromptOrSelectionLikeKey('question'))
+    assert.ok(isPromptOrSelectionLikeKey('prompt'))
+    assert.ok(isPromptOrSelectionLikeKey('query'))
+    assert.ok(isPromptOrSelectionLikeKey('selection'))
+    assert.ok(isPromptOrSelectionLikeKey('selectiontext'))
+    assert.ok(isPromptOrSelectionLikeKey('systemprompt'))
+    assert.ok(isPromptOrSelectionLikeKey('user_question'))
+    assert.ok(isPromptOrSelectionLikeKey('searchquery'))
+  })
+
+  test('rejects unrelated keys', () => {
+    assert.ok(!isPromptOrSelectionLikeKey('name'))
+    assert.ok(!isPromptOrSelectionLikeKey('apikey'))
+    assert.ok(!isPromptOrSelectionLikeKey('enabled'))
+    assert.ok(!isPromptOrSelectionLikeKey('count'))
+    assert.ok(!isPromptOrSelectionLikeKey('model'))
+  })
+})

--- a/tests/unit/config/config-predicates.test.mjs
+++ b/tests/unit/config/config-predicates.test.mjs
@@ -1,12 +1,25 @@
 import assert from 'node:assert/strict'
-import { afterEach, test } from 'node:test'
+import { afterEach, beforeEach, describe, test } from 'node:test'
 import {
   getNavigatorLanguage,
+  getPreferredLanguageKey,
+  isUsingAimlApiModel,
+  isUsingAzureOpenAiApiModel,
   isUsingBingWebModel,
+  isUsingChatGLMApiModel,
   isUsingChatgptApiModel,
+  isUsingClaudeApiModel,
   isUsingCustomModel,
+  isUsingCustomNameOnlyModel,
+  isUsingDeepSeekApiModel,
+  isUsingGeminiWebModel,
+  isUsingGithubThirdPartyApiModel,
+  isUsingMoonshotApiModel,
+  isUsingMoonshotWebModel,
   isUsingMultiModeModel,
+  isUsingOllamaApiModel,
   isUsingOpenAiApiModel,
+  isUsingOpenRouterApiModel,
 } from '../../../src/config/index.mjs'
 
 const originalNavigatorDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'navigator')
@@ -84,4 +97,103 @@ test('isUsingMultiModeModel currently follows Bing web group behavior', () => {
   assert.equal(isUsingMultiModeModel({ modelName: 'bingFree4' }), true)
   assert.equal(isUsingBingWebModel({ modelName: 'chatgptFree35' }), false)
   assert.equal(isUsingMultiModeModel({ modelName: 'chatgptFree35' }), false)
+})
+
+// ── isUsing* predicate wrappers for remaining providers ──────────────
+
+test('isUsingMoonshotWebModel detects moonshot web models', () => {
+  assert.equal(isUsingMoonshotWebModel({ modelName: 'moonshotWebFree' }), true)
+  assert.equal(isUsingMoonshotWebModel({ modelName: 'moonshotWebFreeK15' }), true)
+  assert.equal(isUsingMoonshotWebModel({ modelName: 'chatgptFree35' }), false)
+})
+
+test('isUsingGeminiWebModel detects bard/gemini web models', () => {
+  assert.equal(isUsingGeminiWebModel({ modelName: 'bardWebFree' }), true)
+  assert.equal(isUsingGeminiWebModel({ modelName: 'chatgptFree35' }), false)
+})
+
+test('isUsingClaudeApiModel detects Claude API models', () => {
+  assert.equal(isUsingClaudeApiModel({ modelName: 'claude37SonnetApi' }), true)
+  assert.equal(isUsingClaudeApiModel({ modelName: 'claudeOpus4Api' }), true)
+  assert.equal(isUsingClaudeApiModel({ modelName: 'claude2WebFree' }), false)
+})
+
+test('isUsingMoonshotApiModel detects moonshot API models', () => {
+  assert.equal(isUsingMoonshotApiModel({ modelName: 'moonshot_v1_8k' }), true)
+  assert.equal(isUsingMoonshotApiModel({ modelName: 'moonshot_k2' }), true)
+  assert.equal(isUsingMoonshotApiModel({ modelName: 'moonshotWebFree' }), false)
+})
+
+test('isUsingDeepSeekApiModel detects DeepSeek models', () => {
+  assert.equal(isUsingDeepSeekApiModel({ modelName: 'deepseek_chat' }), true)
+  assert.equal(isUsingDeepSeekApiModel({ modelName: 'deepseek_reasoner' }), true)
+  assert.equal(isUsingDeepSeekApiModel({ modelName: 'chatgptApi4oMini' }), false)
+})
+
+test('isUsingOpenRouterApiModel detects OpenRouter models', () => {
+  assert.equal(
+    isUsingOpenRouterApiModel({ modelName: 'openRouter_anthropic_claude_sonnet4' }),
+    true,
+  )
+  assert.equal(isUsingOpenRouterApiModel({ modelName: 'openRouter_openai_o3' }), true)
+  assert.equal(isUsingOpenRouterApiModel({ modelName: 'chatgptApi4oMini' }), false)
+})
+
+test('isUsingAimlApiModel detects AI/ML models', () => {
+  assert.equal(isUsingAimlApiModel({ modelName: 'aiml_claude_3_7_sonnet_20250219' }), true)
+  assert.equal(isUsingAimlApiModel({ modelName: 'chatgptApi4oMini' }), false)
+})
+
+test('isUsingChatGLMApiModel detects ChatGLM models', () => {
+  assert.equal(isUsingChatGLMApiModel({ modelName: 'chatglmTurbo' }), true)
+  assert.equal(isUsingChatGLMApiModel({ modelName: 'chatglm4' }), true)
+  assert.equal(isUsingChatGLMApiModel({ modelName: 'chatgptApi4oMini' }), false)
+})
+
+test('isUsingOllamaApiModel detects Ollama models', () => {
+  assert.equal(isUsingOllamaApiModel({ modelName: 'ollamaModel' }), true)
+  assert.equal(isUsingOllamaApiModel({ modelName: 'customModel' }), false)
+})
+
+test('isUsingAzureOpenAiApiModel detects Azure OpenAI models', () => {
+  assert.equal(isUsingAzureOpenAiApiModel({ modelName: 'azureOpenAi' }), true)
+  assert.equal(isUsingAzureOpenAiApiModel({ modelName: 'chatgptApi4oMini' }), false)
+})
+
+test('isUsingGithubThirdPartyApiModel detects waylaidwanderer models', () => {
+  assert.equal(isUsingGithubThirdPartyApiModel({ modelName: 'waylaidwandererApi' }), true)
+  assert.equal(isUsingGithubThirdPartyApiModel({ modelName: 'chatgptApi4oMini' }), false)
+})
+
+test('isUsingCustomNameOnlyModel detects poeAiWebCustom', () => {
+  assert.equal(isUsingCustomNameOnlyModel({ modelName: 'poeAiWebCustom' }), true)
+  assert.equal(isUsingCustomNameOnlyModel({ modelName: 'poeAiWebSage' }), false)
+  assert.equal(isUsingCustomNameOnlyModel({ modelName: 'customModel' }), false)
+})
+
+// ── getPreferredLanguageKey ──────────────────────────────────────────
+
+describe('getPreferredLanguageKey', () => {
+  beforeEach(() => {
+    globalThis.__TEST_BROWSER_SHIM__.clearStorage()
+  })
+
+  test('returns stored preferredLanguage', async () => {
+    globalThis.__TEST_BROWSER_SHIM__.setStorage({ preferredLanguage: 'fr' })
+    const key = await getPreferredLanguageKey()
+    assert.equal(key, 'fr')
+  })
+
+  test('falls back to userLanguage when preference is auto', async () => {
+    globalThis.__TEST_BROWSER_SHIM__.setStorage({ preferredLanguage: 'auto' })
+    const key = await getPreferredLanguageKey()
+    // defaultConfig.userLanguage is derived from navigator.language ('en-US' → 'en')
+    assert.equal(key, 'en')
+  })
+
+  test('uses defaultConfig when storage is empty', async () => {
+    // defaultConfig.preferredLanguage = getNavigatorLanguage() which is 'en' in the shim
+    const key = await getPreferredLanguageKey()
+    assert.equal(key, 'en')
+  })
 })

--- a/tests/unit/content-script/selection-tools.test.mjs
+++ b/tests/unit/content-script/selection-tools.test.mjs
@@ -1,0 +1,189 @@
+/* eslint-disable no-undef */
+import assert from 'node:assert/strict'
+import { register } from 'node:module'
+import { afterEach, before, describe, test } from 'node:test'
+import { pathToFileURL } from 'node:url'
+
+// Register JSX/CJS loader hooks so the selection-tools module can be imported.
+register('./tests/setup/jsx-loader-hooks.mjs', pathToFileURL(process.cwd() + '/').href)
+
+let config
+
+before(async () => {
+  const m = await import('../../../src/content-script/selection-tools/index.mjs')
+  config = m.config
+})
+
+afterEach(() => {
+  globalThis.__TEST_BROWSER_SHIM__.clearStorage()
+})
+
+// ── helpers ──────────────────────────────────────────────────────────
+
+const wrappedBlock = (text) => `\n'''\n${text}\n'''`
+
+// ── basic genPrompt output for every tool ────────────────────────────
+
+describe('selection-tools genPrompt', () => {
+  test('explain includes language prefix and explanation instruction', async () => {
+    const result = await config.explain.genPrompt('some concept')
+    assert.ok(result.startsWith('Reply in English.'))
+    assert.ok(result.includes('Explain the following content'))
+    assert.ok(result.endsWith(wrappedBlock('some concept')))
+  })
+
+  test('translate produces translation prompt with preferred language', async () => {
+    const result = await config.translate.genPrompt('bonjour')
+    assert.ok(result.includes('Translate the following text into English'))
+    assert.ok(result.endsWith(wrappedBlock('bonjour')))
+    // translate has no language prefix
+    assert.ok(!result.startsWith('Reply in'))
+  })
+
+  test('translateToEn always targets English regardless of preference', async () => {
+    globalThis.__TEST_BROWSER_SHIM__.setStorage({ preferredLanguage: 'ja' })
+    const result = await config.translateToEn.genPrompt('hola')
+    assert.ok(result.includes('Translate the following text into English'))
+    assert.ok(result.endsWith(wrappedBlock('hola')))
+  })
+
+  test('translateToZh always targets Chinese', async () => {
+    const result = await config.translateToZh.genPrompt('hello')
+    assert.ok(result.includes('Translate the following text into Chinese'))
+    assert.ok(result.endsWith(wrappedBlock('hello')))
+  })
+
+  test('translateBidi includes bidirectional fallback instruction', async () => {
+    const result = await config.translateBidi.genPrompt('hello')
+    assert.ok(result.includes('Translate the following text into English'))
+    assert.ok(result.includes('translate it into English instead'))
+    assert.ok(result.endsWith(wrappedBlock('hello')))
+  })
+
+  test('summary includes summarization instruction with language prefix', async () => {
+    const result = await config.summary.genPrompt('long article')
+    assert.ok(result.startsWith('Reply in English.'))
+    assert.ok(result.includes('Summarize the following content'))
+    assert.ok(result.endsWith(wrappedBlock('long article')))
+  })
+
+  test('polish has no language prefix', async () => {
+    const result = await config.polish.genPrompt('bad grammer')
+    assert.ok(!result.startsWith('Reply in'))
+    assert.ok(result.includes('Correct grammar'))
+    assert.ok(result.endsWith(wrappedBlock('bad grammer')))
+  })
+
+  test('sentiment includes language prefix and analysis instruction', async () => {
+    const result = await config.sentiment.genPrompt('I love this')
+    assert.ok(result.startsWith('Reply in English.'))
+    assert.ok(result.includes('sentiment analysis'))
+    assert.ok(result.endsWith(wrappedBlock('I love this')))
+  })
+
+  test('divide has no language prefix', async () => {
+    const result = await config.divide.genPrompt('wall of text')
+    assert.ok(!result.startsWith('Reply in'))
+    assert.ok(result.includes('Divide the following text'))
+    assert.ok(result.endsWith(wrappedBlock('wall of text')))
+  })
+
+  test('code includes language prefix and code explanation instruction', async () => {
+    const result = await config.code.genPrompt('const x = 1')
+    assert.ok(result.startsWith('Reply in English.'))
+    assert.ok(result.includes('Break down the following code'))
+    assert.ok(result.endsWith(wrappedBlock('const x = 1')))
+  })
+
+  test('ask includes language prefix', async () => {
+    const result = await config.ask.genPrompt('why is the sky blue?')
+    assert.ok(result.startsWith('Reply in English.'))
+    assert.ok(result.includes('Analyze the following content'))
+    assert.ok(result.endsWith(wrappedBlock('why is the sky blue?')))
+  })
+})
+
+// ── translation tools honour language parameter ──────────────────────
+
+describe('translation tools respect language settings', () => {
+  test('translate uses preferred language from config', async () => {
+    globalThis.__TEST_BROWSER_SHIM__.setStorage({ preferredLanguage: 'ja' })
+    const result = await config.translate.genPrompt('hello')
+    assert.ok(result.includes('Translate the following text into Japanese'))
+  })
+
+  test('translate falls back to navigator language when preference is auto', async () => {
+    globalThis.__TEST_BROWSER_SHIM__.setStorage({ preferredLanguage: 'auto' })
+    const result = await config.translate.genPrompt('hello')
+    // navigator.language is 'en-US' via browser shim → userLanguage 'en' → English
+    assert.ok(result.includes('Translate the following text into English'))
+  })
+
+  test('translateToEn ignores preferred language', async () => {
+    globalThis.__TEST_BROWSER_SHIM__.setStorage({ preferredLanguage: 'fr' })
+    const result = await config.translateToEn.genPrompt('hello')
+    assert.ok(result.includes('into English'))
+    assert.ok(!result.includes('into French'))
+  })
+
+  test('translateToZh ignores preferred language', async () => {
+    globalThis.__TEST_BROWSER_SHIM__.setStorage({ preferredLanguage: 'de' })
+    const result = await config.translateToZh.genPrompt('hello')
+    assert.ok(result.includes('into Chinese'))
+    assert.ok(!result.includes('into German'))
+  })
+
+  test('explain language prefix reflects preferred language', async () => {
+    globalThis.__TEST_BROWSER_SHIM__.setStorage({ preferredLanguage: 'fr' })
+    const result = await config.explain.genPrompt('text')
+    assert.ok(result.startsWith('Reply in French.'))
+  })
+})
+
+// ── bidirectional translation toggle ─────────────────────────────────
+
+describe('bidirectional translation toggle', () => {
+  test('translateBidi includes bidirectional instruction', async () => {
+    const result = await config.translateBidi.genPrompt('text')
+    assert.ok(result.includes('If the text is already in'))
+    assert.ok(result.includes('translate it into English instead'))
+  })
+
+  test('translate does NOT include bidirectional instruction', async () => {
+    const result = await config.translate.genPrompt('text')
+    assert.ok(!result.includes('If the text is already in'))
+  })
+
+  test('translateToEn does NOT include bidirectional instruction', async () => {
+    const result = await config.translateToEn.genPrompt('text')
+    assert.ok(!result.includes('If the text is already in'))
+  })
+
+  test('translateBidi uses preferred language in bidirectional clause', async () => {
+    globalThis.__TEST_BROWSER_SHIM__.setStorage({ preferredLanguage: 'ja' })
+    const result = await config.translateBidi.genPrompt('text')
+    assert.ok(result.includes('into Japanese'))
+    assert.ok(result.includes('If the text is already in Japanese'))
+  })
+})
+
+// ── empty selection ──────────────────────────────────────────────────
+
+describe('empty selection handled gracefully', () => {
+  test('explain with empty string still produces valid prompt', async () => {
+    const result = await config.explain.genPrompt('')
+    assert.ok(result.includes("'''"))
+    assert.ok(result.endsWith(wrappedBlock('')))
+  })
+
+  test('translate with empty string still produces valid prompt', async () => {
+    const result = await config.translate.genPrompt('')
+    assert.ok(result.includes('Translate the following text'))
+    assert.ok(result.endsWith(wrappedBlock('')))
+  })
+
+  test('polish with empty string still produces valid prompt', async () => {
+    const result = await config.polish.genPrompt('')
+    assert.ok(result.endsWith(wrappedBlock('')))
+  })
+})

--- a/tests/unit/services/apis/azure-openai-api.test.mjs
+++ b/tests/unit/services/apis/azure-openai-api.test.mjs
@@ -1,0 +1,261 @@
+import assert from 'node:assert/strict'
+import { beforeEach, test } from 'node:test'
+import { generateAnswersWithAzureOpenaiApi } from '../../../../src/services/apis/azure-openai-api.mjs'
+import { createFakePort } from '../../helpers/port.mjs'
+import { createMockSseResponse } from '../../helpers/sse-response.mjs'
+
+const setStorage = (values) => {
+  globalThis.__TEST_BROWSER_SHIM__.replaceStorage(values)
+}
+
+beforeEach(() => {
+  globalThis.__TEST_BROWSER_SHIM__.clearStorage()
+})
+
+test('azure-openai: composes URL, strips trailing slash, sends api-key header', async (t) => {
+  t.mock.method(console, 'debug', () => {})
+  setStorage({
+    azureEndpoint: 'https://myinstance.openai.azure.com/',
+    azureApiKey: 'az-key-123',
+    azureDeploymentName: 'gpt-4o',
+    maxConversationContextLength: 3,
+    maxResponseTokenLength: 512,
+    temperature: 0.7,
+  })
+
+  const session = {
+    modelName: 'azureOpenAi',
+    conversationRecords: [],
+    isRetry: false,
+  }
+  const port = createFakePort()
+
+  let capturedInput
+  let capturedInit
+  t.mock.method(globalThis, 'fetch', async (input, init) => {
+    capturedInput = input
+    capturedInit = init
+    return createMockSseResponse([
+      'data: {"choices":[{"delta":{"content":"Hi"},"finish_reason":"stop"}]}\n\n',
+    ])
+  })
+
+  await generateAnswersWithAzureOpenaiApi(port, 'Hello', session)
+
+  assert.equal(
+    capturedInput,
+    'https://myinstance.openai.azure.com/openai/deployments/gpt-4o/chat/completions?api-version=2024-02-01',
+  )
+  assert.equal(capturedInit.headers['api-key'], 'az-key-123')
+  assert.equal(capturedInit.headers['Content-Type'], 'application/json')
+})
+
+test('azure-openai: endpoint without trailing slash works', async (t) => {
+  t.mock.method(console, 'debug', () => {})
+  setStorage({
+    azureEndpoint: 'https://myinstance.openai.azure.com',
+    azureApiKey: 'az-key-456',
+    azureDeploymentName: 'gpt-4o',
+    maxConversationContextLength: 3,
+    maxResponseTokenLength: 256,
+    temperature: 0.5,
+  })
+
+  const session = {
+    modelName: 'azureOpenAi',
+    conversationRecords: [],
+    isRetry: false,
+  }
+  const port = createFakePort()
+
+  let capturedInput
+  t.mock.method(globalThis, 'fetch', async (input) => {
+    capturedInput = input
+    return createMockSseResponse([
+      'data: {"choices":[{"delta":{"content":"OK"},"finish_reason":"stop"}]}\n\n',
+    ])
+  })
+
+  await generateAnswersWithAzureOpenaiApi(port, 'Q', session)
+
+  assert.equal(
+    capturedInput,
+    'https://myinstance.openai.azure.com/openai/deployments/gpt-4o/chat/completions?api-version=2024-02-01',
+  )
+})
+
+test('azure-openai: uses resolved model value when non-empty (skips fallback)', async (t) => {
+  t.mock.method(console, 'debug', () => {})
+  setStorage({
+    azureEndpoint: 'https://myinstance.openai.azure.com',
+    azureApiKey: 'az-key',
+    azureDeploymentName: 'should-not-use',
+    maxConversationContextLength: 3,
+    maxResponseTokenLength: 128,
+    temperature: 0.3,
+  })
+
+  // Custom model name that resolves to non-empty 'my-gpt4' via split('-').slice(1).join('-')
+  const session = {
+    modelName: 'azureOpenAi-my-gpt4',
+    conversationRecords: [],
+    isRetry: false,
+  }
+  const port = createFakePort()
+
+  let capturedInput
+  t.mock.method(globalThis, 'fetch', async (input) => {
+    capturedInput = input
+    return createMockSseResponse([
+      'data: {"choices":[{"delta":{"content":"OK"},"finish_reason":"stop"}]}\n\n',
+    ])
+  })
+
+  await generateAnswersWithAzureOpenaiApi(port, 'Q', session)
+
+  assert.match(capturedInput, /\/deployments\/my-gpt4\//)
+  assert.ok(!capturedInput.includes('should-not-use'))
+})
+
+test('azure-openai: sends max_tokens and temperature in body', async (t) => {
+  t.mock.method(console, 'debug', () => {})
+  setStorage({
+    azureEndpoint: 'https://myinstance.openai.azure.com',
+    azureApiKey: 'az-key',
+    azureDeploymentName: 'gpt-4o',
+    maxConversationContextLength: 3,
+    maxResponseTokenLength: 1024,
+    temperature: 0.9,
+  })
+
+  const session = {
+    modelName: 'azureOpenAi',
+    conversationRecords: [],
+    isRetry: false,
+  }
+  const port = createFakePort()
+
+  let capturedInit
+  t.mock.method(globalThis, 'fetch', async (_input, init) => {
+    capturedInit = init
+    return createMockSseResponse([
+      'data: {"choices":[{"delta":{"content":"OK"},"finish_reason":"stop"}]}\n\n',
+    ])
+  })
+
+  await generateAnswersWithAzureOpenaiApi(port, 'Q', session)
+
+  const body = JSON.parse(capturedInit.body)
+  assert.equal(body.max_tokens, 1024)
+  assert.equal(body.temperature, 0.9)
+  assert.equal(body.stream, true)
+})
+
+test('azure-openai: aggregates SSE deltas and pushes record on finish', async (t) => {
+  t.mock.method(console, 'debug', () => {})
+  setStorage({
+    azureEndpoint: 'https://myinstance.openai.azure.com',
+    azureApiKey: 'az-key',
+    azureDeploymentName: 'gpt-4o',
+    maxConversationContextLength: 3,
+    maxResponseTokenLength: 256,
+    temperature: 0.5,
+  })
+
+  const session = {
+    modelName: 'azureOpenAi',
+    conversationRecords: [{ question: 'PrevQ', answer: 'PrevA' }],
+    isRetry: false,
+  }
+  const port = createFakePort()
+
+  t.mock.method(globalThis, 'fetch', async () =>
+    createMockSseResponse([
+      'data: {"choices":[{"delta":{"content":"Hel"}}]}\n\n',
+      'data: {"choices":[{"delta":{"content":"lo"},"finish_reason":"stop"}]}\n\n',
+    ]),
+  )
+
+  await generateAnswersWithAzureOpenaiApi(port, 'CurrentQ', session)
+
+  assert.equal(
+    port.postedMessages.some((m) => m.done === false && m.answer === 'Hel'),
+    true,
+  )
+  assert.equal(
+    port.postedMessages.some((m) => m.done === false && m.answer === 'Hello'),
+    true,
+  )
+  assert.equal(
+    port.postedMessages.some((m) => m.done === true && m.session === session),
+    true,
+  )
+  assert.deepEqual(port.postedMessages.at(-1), { done: true })
+  assert.deepEqual(session.conversationRecords.at(-1), {
+    question: 'CurrentQ',
+    answer: 'Hello',
+  })
+})
+
+test('azure-openai: cleans up listeners on end', async (t) => {
+  t.mock.method(console, 'debug', () => {})
+  setStorage({
+    azureEndpoint: 'https://myinstance.openai.azure.com',
+    azureApiKey: 'az-key',
+    azureDeploymentName: 'gpt-4o',
+    maxConversationContextLength: 3,
+    maxResponseTokenLength: 128,
+    temperature: 0.1,
+  })
+
+  const session = {
+    modelName: 'azureOpenAi',
+    conversationRecords: [],
+    isRetry: false,
+  }
+  const port = createFakePort()
+
+  t.mock.method(globalThis, 'fetch', async () =>
+    createMockSseResponse([
+      'data: {"choices":[{"delta":{"content":"OK"},"finish_reason":"stop"}]}\n\n',
+    ]),
+  )
+
+  await generateAnswersWithAzureOpenaiApi(port, 'Q', session)
+
+  assert.deepEqual(port.listenerCounts(), { onMessage: 0, onDisconnect: 0 })
+})
+
+test('azure-openai: throws on error response with JSON body', async (t) => {
+  t.mock.method(console, 'debug', () => {})
+  setStorage({
+    azureEndpoint: 'https://myinstance.openai.azure.com',
+    azureApiKey: 'bad-key',
+    azureDeploymentName: 'gpt-4o',
+    maxConversationContextLength: 3,
+    maxResponseTokenLength: 128,
+    temperature: 0.1,
+  })
+
+  const session = {
+    modelName: 'azureOpenAi',
+    conversationRecords: [],
+    isRetry: false,
+  }
+  const port = createFakePort()
+
+  t.mock.method(globalThis, 'fetch', async () =>
+    createMockSseResponse([], {
+      ok: false,
+      status: 401,
+      statusText: 'Unauthorized',
+      json: async () => ({ error: { message: 'invalid subscription key' } }),
+    }),
+  )
+
+  await assert.rejects(
+    async () => generateAnswersWithAzureOpenaiApi(port, 'Q', session),
+    /invalid subscription key/,
+  )
+  assert.deepEqual(port.listenerCounts(), { onMessage: 0, onDisconnect: 0 })
+})

--- a/tests/unit/services/apis/claude-api.test.mjs
+++ b/tests/unit/services/apis/claude-api.test.mjs
@@ -1,0 +1,254 @@
+import assert from 'node:assert/strict'
+import { beforeEach, test } from 'node:test'
+import { generateAnswersWithClaudeApi } from '../../../../src/services/apis/claude-api.mjs'
+import { createFakePort } from '../../helpers/port.mjs'
+import { createMockSseResponse } from '../../helpers/sse-response.mjs'
+
+const setStorage = (values) => {
+  globalThis.__TEST_BROWSER_SHIM__.replaceStorage(values)
+}
+
+beforeEach(() => {
+  globalThis.__TEST_BROWSER_SHIM__.clearStorage()
+})
+
+test('claude-api: sends correct URL and headers', async (t) => {
+  t.mock.method(console, 'debug', () => {})
+  setStorage({
+    customClaudeApiUrl: 'https://api.anthropic.com',
+    claudeApiKey: 'sk-ant-test',
+    maxConversationContextLength: 3,
+    maxResponseTokenLength: 512,
+    temperature: 0.7,
+  })
+
+  const session = {
+    modelName: 'claude37SonnetApi',
+    conversationRecords: [],
+    isRetry: false,
+  }
+  const port = createFakePort()
+
+  let capturedInput
+  let capturedInit
+  t.mock.method(globalThis, 'fetch', async (input, init) => {
+    capturedInput = input
+    capturedInit = init
+    return createMockSseResponse([
+      'data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"Hi"}}\n\n',
+      'data: {"type":"message_stop"}\n\n',
+    ])
+  })
+
+  await generateAnswersWithClaudeApi(port, 'Hello', session)
+
+  assert.equal(capturedInput, 'https://api.anthropic.com/v1/messages')
+  assert.equal(capturedInit.headers['x-api-key'], 'sk-ant-test')
+  assert.equal(capturedInit.headers['anthropic-version'], '2023-06-01')
+  assert.equal(capturedInit.headers['anthropic-dangerous-direct-browser-access'], true)
+  assert.equal(capturedInit.headers['Content-Type'], 'application/json')
+})
+
+test('claude-api: sends model, max_tokens, temperature in body', async (t) => {
+  t.mock.method(console, 'debug', () => {})
+  setStorage({
+    customClaudeApiUrl: 'https://api.anthropic.com',
+    claudeApiKey: 'sk-ant-test',
+    maxConversationContextLength: 3,
+    maxResponseTokenLength: 1024,
+    temperature: 0.9,
+  })
+
+  const session = {
+    modelName: 'claude37SonnetApi',
+    conversationRecords: [],
+    isRetry: false,
+  }
+  const port = createFakePort()
+
+  let capturedInit
+  t.mock.method(globalThis, 'fetch', async (_input, init) => {
+    capturedInit = init
+    return createMockSseResponse([
+      'data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"OK"}}\n\n',
+      'data: {"type":"message_stop"}\n\n',
+    ])
+  })
+
+  await generateAnswersWithClaudeApi(port, 'Q', session)
+
+  const body = JSON.parse(capturedInit.body)
+  assert.equal(body.model, 'claude-3-7-sonnet-20250219')
+  assert.equal(body.max_tokens, 1024)
+  assert.equal(body.temperature, 0.9)
+  assert.equal(body.stream, true)
+})
+
+test('claude-api: delta.text streams accumulate and message_stop terminates', async (t) => {
+  t.mock.method(console, 'debug', () => {})
+  setStorage({
+    customClaudeApiUrl: 'https://api.anthropic.com',
+    claudeApiKey: 'sk-ant-test',
+    maxConversationContextLength: 3,
+    maxResponseTokenLength: 256,
+    temperature: 0.5,
+  })
+
+  const session = {
+    modelName: 'claude37SonnetApi',
+    conversationRecords: [{ question: 'PrevQ', answer: 'PrevA' }],
+    isRetry: false,
+  }
+  const port = createFakePort()
+
+  t.mock.method(globalThis, 'fetch', async () =>
+    createMockSseResponse([
+      'data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"Hel"}}\n\n',
+      'data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"lo"}}\n\n',
+      'data: {"type":"message_stop"}\n\n',
+    ]),
+  )
+
+  await generateAnswersWithClaudeApi(port, 'CurrentQ', session)
+
+  assert.equal(
+    port.postedMessages.some((m) => m.done === false && m.answer === 'Hel'),
+    true,
+  )
+  assert.equal(
+    port.postedMessages.some((m) => m.done === false && m.answer === 'Hello'),
+    true,
+  )
+  assert.equal(
+    port.postedMessages.some((m) => m.done === true && m.session === session),
+    true,
+  )
+  assert.deepEqual(port.postedMessages.at(-1), { done: true })
+})
+
+test('claude-api: pushRecord on message_stop', async (t) => {
+  t.mock.method(console, 'debug', () => {})
+  setStorage({
+    customClaudeApiUrl: 'https://api.anthropic.com',
+    claudeApiKey: 'sk-ant-test',
+    maxConversationContextLength: 3,
+    maxResponseTokenLength: 256,
+    temperature: 0.5,
+  })
+
+  const session = {
+    modelName: 'claude37SonnetApi',
+    conversationRecords: [],
+    isRetry: false,
+  }
+  const port = createFakePort()
+
+  t.mock.method(globalThis, 'fetch', async () =>
+    createMockSseResponse([
+      'data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"Answer"}}\n\n',
+      'data: {"type":"message_stop"}\n\n',
+    ]),
+  )
+
+  await generateAnswersWithClaudeApi(port, 'MyQ', session)
+
+  assert.deepEqual(session.conversationRecords.at(-1), {
+    question: 'MyQ',
+    answer: 'Answer',
+  })
+})
+
+test('claude-api: cleans up listeners on end', async (t) => {
+  t.mock.method(console, 'debug', () => {})
+  setStorage({
+    customClaudeApiUrl: 'https://api.anthropic.com',
+    claudeApiKey: 'sk-ant-test',
+    maxConversationContextLength: 3,
+    maxResponseTokenLength: 128,
+    temperature: 0.1,
+  })
+
+  const session = {
+    modelName: 'claude37SonnetApi',
+    conversationRecords: [],
+    isRetry: false,
+  }
+  const port = createFakePort()
+
+  t.mock.method(globalThis, 'fetch', async () =>
+    createMockSseResponse([
+      'data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"OK"}}\n\n',
+      'data: {"type":"message_stop"}\n\n',
+    ]),
+  )
+
+  await generateAnswersWithClaudeApi(port, 'Q', session)
+
+  assert.deepEqual(port.listenerCounts(), { onMessage: 0, onDisconnect: 0 })
+})
+
+test('claude-api: throws on error response', async (t) => {
+  t.mock.method(console, 'debug', () => {})
+  setStorage({
+    customClaudeApiUrl: 'https://api.anthropic.com',
+    claudeApiKey: 'bad-key',
+    maxConversationContextLength: 3,
+    maxResponseTokenLength: 128,
+    temperature: 0.1,
+  })
+
+  const session = {
+    modelName: 'claude37SonnetApi',
+    conversationRecords: [],
+    isRetry: false,
+  }
+  const port = createFakePort()
+
+  t.mock.method(globalThis, 'fetch', async () =>
+    createMockSseResponse([], {
+      ok: false,
+      status: 401,
+      statusText: 'Unauthorized',
+      json: async () => ({ error: { message: 'invalid x-api-key' } }),
+    }),
+  )
+
+  await assert.rejects(
+    async () => generateAnswersWithClaudeApi(port, 'Q', session),
+    /invalid x-api-key/,
+  )
+  assert.deepEqual(port.listenerCounts(), { onMessage: 0, onDisconnect: 0 })
+})
+
+test('claude-api: ignores unparseable JSON messages', async (t) => {
+  t.mock.method(console, 'debug', () => {})
+  setStorage({
+    customClaudeApiUrl: 'https://api.anthropic.com',
+    claudeApiKey: 'sk-ant-test',
+    maxConversationContextLength: 3,
+    maxResponseTokenLength: 256,
+    temperature: 0.5,
+  })
+
+  const session = {
+    modelName: 'claude37SonnetApi',
+    conversationRecords: [],
+    isRetry: false,
+  }
+  const port = createFakePort()
+
+  t.mock.method(globalThis, 'fetch', async () =>
+    createMockSseResponse([
+      'data: not-valid-json\n\n',
+      'data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"OK"}}\n\n',
+      'data: {"type":"message_stop"}\n\n',
+    ]),
+  )
+
+  await generateAnswersWithClaudeApi(port, 'Q', session)
+
+  assert.equal(
+    port.postedMessages.some((m) => m.done === false && m.answer === 'OK'),
+    true,
+  )
+})

--- a/tests/unit/services/apis/custom-api.test.mjs
+++ b/tests/unit/services/apis/custom-api.test.mjs
@@ -1,0 +1,597 @@
+import assert from 'node:assert/strict'
+import { beforeEach, test } from 'node:test'
+import { generateAnswersWithCustomApi } from '../../../../src/services/apis/custom-api.mjs'
+import { createFakePort } from '../../helpers/port.mjs'
+import { createMockSseResponse } from '../../helpers/sse-response.mjs'
+
+const setStorage = (values) => {
+  globalThis.__TEST_BROWSER_SHIM__.replaceStorage(values)
+}
+
+beforeEach(() => {
+  globalThis.__TEST_BROWSER_SHIM__.clearStorage()
+})
+
+test('aggregates delta.content SSE chunks and finishes on finish_reason', async (t) => {
+  t.mock.method(console, 'debug', () => {})
+  setStorage({
+    maxConversationContextLength: 3,
+    maxResponseTokenLength: 256,
+    temperature: 0.5,
+  })
+
+  const session = {
+    modelName: 'customModel',
+    conversationRecords: [{ question: 'PrevQ', answer: 'PrevA' }],
+    isRetry: false,
+  }
+  const port = createFakePort()
+
+  let capturedInput
+  let capturedInit
+  t.mock.method(globalThis, 'fetch', async (input, init) => {
+    capturedInput = input
+    capturedInit = init
+    return createMockSseResponse([
+      'data: {"choices":[{"delta":{"content":"Hel"}}]}\n\n',
+      'data: {"choices":[{"delta":{"content":"lo"},"finish_reason":"stop"}]}\n\n',
+    ])
+  })
+
+  await generateAnswersWithCustomApi(
+    port,
+    'CurrentQ',
+    session,
+    'https://custom.api/v1/chat',
+    'key-123',
+    'custom-model',
+  )
+
+  assert.equal(capturedInput, 'https://custom.api/v1/chat')
+  assert.equal(capturedInit.method, 'POST')
+  assert.equal(capturedInit.headers.Authorization, 'Bearer key-123')
+
+  const body = JSON.parse(capturedInit.body)
+  assert.equal(body.stream, true)
+  assert.equal(body.model, 'custom-model')
+  assert.equal(body.temperature, 0.5)
+  assert.equal(Array.isArray(body.messages), true)
+  assert.deepEqual(body.messages[0], { role: 'user', content: 'PrevQ' })
+  assert.deepEqual(body.messages[1], { role: 'assistant', content: 'PrevA' })
+  assert.deepEqual(body.messages.at(-1), { role: 'user', content: 'CurrentQ' })
+
+  assert.equal(
+    port.postedMessages.some((m) => m.done === false && m.answer === 'Hel'),
+    true,
+  )
+  assert.equal(
+    port.postedMessages.some((m) => m.done === false && m.answer === 'Hello'),
+    true,
+  )
+  assert.equal(
+    port.postedMessages.some((m) => m.done === true && m.session === session),
+    true,
+  )
+  assert.deepEqual(port.postedMessages.at(-1), { done: true })
+  assert.deepEqual(session.conversationRecords.at(-1), {
+    question: 'CurrentQ',
+    answer: 'Hello',
+  })
+})
+
+test('handles message.content response schema', async (t) => {
+  t.mock.method(console, 'debug', () => {})
+  setStorage({
+    maxConversationContextLength: 2,
+    maxResponseTokenLength: 128,
+    temperature: 0.3,
+  })
+
+  const session = {
+    modelName: 'customModel',
+    conversationRecords: [],
+    isRetry: false,
+  }
+  const port = createFakePort()
+
+  t.mock.method(globalThis, 'fetch', async () =>
+    createMockSseResponse([
+      'data: {"choices":[{"message":{"content":"Full answer"},"finish_reason":"stop"}]}\n\n',
+    ]),
+  )
+
+  await generateAnswersWithCustomApi(
+    port,
+    'Q',
+    session,
+    'https://custom.api/v1/chat',
+    'key',
+    'model',
+  )
+
+  assert.equal(
+    port.postedMessages.some((m) => m.done === false && m.answer === 'Full answer'),
+    true,
+  )
+  assert.deepEqual(session.conversationRecords.at(-1), {
+    question: 'Q',
+    answer: 'Full answer',
+  })
+})
+
+test('ignores null message.content to avoid null-prefixed answers', async (t) => {
+  t.mock.method(console, 'debug', () => {})
+  setStorage({
+    maxConversationContextLength: 2,
+    maxResponseTokenLength: 128,
+    temperature: 0.3,
+  })
+
+  const session = {
+    modelName: 'customModel',
+    conversationRecords: [],
+    isRetry: false,
+  }
+  const port = createFakePort()
+
+  t.mock.method(globalThis, 'fetch', async () =>
+    createMockSseResponse([
+      'data: {"choices":[{"message":{"content":null}}]}\n\n',
+      'data: {"choices":[{"delta":{"content":"Hi"},"finish_reason":"stop"}]}\n\n',
+    ]),
+  )
+
+  await generateAnswersWithCustomApi(
+    port,
+    'Q',
+    session,
+    'https://custom.api/v1/chat',
+    'key',
+    'model',
+  )
+
+  const partialAnswers = port.postedMessages.filter((m) => m.done === false).map((m) => m.answer)
+  assert.equal(partialAnswers.some((a) => a === null), false)
+  assert.equal(
+    partialAnswers.some((a) => typeof a === 'string' && a.startsWith('null')),
+    false,
+  )
+  assert.equal(partialAnswers.at(-1), 'Hi')
+  assert.deepEqual(session.conversationRecords.at(-1), { question: 'Q', answer: 'Hi' })
+})
+
+test('handles choices[].text response schema', async (t) => {
+  t.mock.method(console, 'debug', () => {})
+  setStorage({
+    maxConversationContextLength: 2,
+    maxResponseTokenLength: 128,
+    temperature: 0.2,
+  })
+
+  const session = {
+    modelName: 'customModel',
+    conversationRecords: [],
+    isRetry: false,
+  }
+  const port = createFakePort()
+
+  t.mock.method(globalThis, 'fetch', async () =>
+    createMockSseResponse([
+      'data: {"choices":[{"text":"A"}]}\n\n',
+      'data: {"choices":[{"text":"B","finish_reason":"stop"}]}\n\n',
+    ]),
+  )
+
+  await generateAnswersWithCustomApi(
+    port,
+    'Q',
+    session,
+    'https://custom.api/v1/chat',
+    'key',
+    'model',
+  )
+
+  assert.equal(
+    port.postedMessages.some((m) => m.done === false && m.answer === 'AB'),
+    true,
+  )
+  assert.deepEqual(session.conversationRecords.at(-1), { question: 'Q', answer: 'AB' })
+})
+
+test('handles {response} field (direct response)', async (t) => {
+  t.mock.method(console, 'debug', () => {})
+  setStorage({
+    maxConversationContextLength: 2,
+    maxResponseTokenLength: 128,
+    temperature: 0.1,
+  })
+
+  const session = {
+    modelName: 'customModel',
+    conversationRecords: [],
+    isRetry: false,
+  }
+  const port = createFakePort()
+
+  t.mock.method(globalThis, 'fetch', async () =>
+    createMockSseResponse([
+      'data: {"response":"Partial"}\n\n',
+      'data: {"response":"Complete answer"}\n\n',
+      'data: [DONE]\n\n',
+    ]),
+  )
+
+  await generateAnswersWithCustomApi(
+    port,
+    'Q',
+    session,
+    'https://custom.api/v1/chat',
+    'key',
+    'model',
+  )
+
+  assert.equal(
+    port.postedMessages.some((m) => m.done === false && m.answer === 'Partial'),
+    true,
+  )
+  assert.equal(
+    port.postedMessages.some((m) => m.done === false && m.answer === 'Complete answer'),
+    true,
+  )
+  assert.deepEqual(session.conversationRecords.at(-1), {
+    question: 'Q',
+    answer: 'Complete answer',
+  })
+})
+
+test('handles [DONE] marker to finish stream', async (t) => {
+  t.mock.method(console, 'debug', () => {})
+  setStorage({
+    maxConversationContextLength: 2,
+    maxResponseTokenLength: 128,
+    temperature: 0.1,
+  })
+
+  const session = {
+    modelName: 'customModel',
+    conversationRecords: [],
+    isRetry: false,
+  }
+  const port = createFakePort()
+
+  t.mock.method(globalThis, 'fetch', async () =>
+    createMockSseResponse([
+      'data: {"choices":[{"delta":{"content":"Done test"}}]}\n\n',
+      'data: [DONE]\n\n',
+    ]),
+  )
+
+  await generateAnswersWithCustomApi(
+    port,
+    'Q',
+    session,
+    'https://custom.api/v1/chat',
+    'key',
+    'model',
+  )
+
+  assert.equal(
+    port.postedMessages.some((m) => m.done === true && m.session === session),
+    true,
+  )
+  assert.deepEqual(session.conversationRecords.at(-1), {
+    question: 'Q',
+    answer: 'Done test',
+  })
+})
+
+test('skips unparseable JSON messages gracefully', async (t) => {
+  t.mock.method(console, 'debug', () => {})
+  setStorage({
+    maxConversationContextLength: 2,
+    maxResponseTokenLength: 128,
+    temperature: 0.1,
+  })
+
+  const session = {
+    modelName: 'customModel',
+    conversationRecords: [],
+    isRetry: false,
+  }
+  const port = createFakePort()
+
+  t.mock.method(globalThis, 'fetch', async () =>
+    createMockSseResponse([
+      'data: not-valid-json\n\n',
+      'data: {"choices":[{"delta":{"content":"OK"},"finish_reason":"stop"}]}\n\n',
+    ]),
+  )
+
+  await generateAnswersWithCustomApi(
+    port,
+    'Q',
+    session,
+    'https://custom.api/v1/chat',
+    'key',
+    'model',
+  )
+
+  assert.equal(
+    port.postedMessages.some((m) => m.done === false && m.answer === 'OK'),
+    true,
+  )
+  assert.deepEqual(session.conversationRecords.at(-1), { question: 'Q', answer: 'OK' })
+})
+
+test('handles metadata-only SSE chunk without choices or response fields', async (t) => {
+  t.mock.method(console, 'debug', () => {})
+  setStorage({
+    maxConversationContextLength: 2,
+    maxResponseTokenLength: 128,
+    temperature: 0.1,
+  })
+
+  const session = {
+    modelName: 'customModel',
+    conversationRecords: [],
+    isRetry: false,
+  }
+  const port = createFakePort()
+
+  t.mock.method(globalThis, 'fetch', async () =>
+    createMockSseResponse([
+      'data: {"id":"chatcmpl-xxx","model":"gpt-4"}\n\n',
+      'data: {"choices":[{"delta":{"content":"Hi"},"finish_reason":"stop"}]}\n\n',
+    ]),
+  )
+
+  await generateAnswersWithCustomApi(
+    port,
+    'Q',
+    session,
+    'https://custom.api/v1/chat',
+    'key',
+    'model',
+  )
+
+  assert.equal(
+    port.postedMessages.some((m) => m.done === false && m.answer === 'Hi'),
+    true,
+  )
+  assert.deepEqual(session.conversationRecords.at(-1), { question: 'Q', answer: 'Hi' })
+})
+
+test('throws on non-ok response with JSON error body', async (t) => {
+  t.mock.method(console, 'debug', () => {})
+  setStorage({
+    maxConversationContextLength: 2,
+    maxResponseTokenLength: 128,
+    temperature: 0.1,
+  })
+
+  const session = {
+    modelName: 'customModel',
+    conversationRecords: [],
+    isRetry: false,
+  }
+  const port = createFakePort()
+
+  t.mock.method(globalThis, 'fetch', async () =>
+    createMockSseResponse([], {
+      ok: false,
+      status: 401,
+      statusText: 'Unauthorized',
+      json: async () => ({ error: { message: 'invalid api key' } }),
+    }),
+  )
+
+  await assert.rejects(
+    () =>
+      generateAnswersWithCustomApi(
+        port,
+        'Q',
+        session,
+        'https://custom.api/v1/chat',
+        'bad-key',
+        'model',
+      ),
+    /invalid api key/,
+  )
+
+  assert.deepEqual(port.listenerCounts(), { onMessage: 0, onDisconnect: 0 })
+})
+
+test('throws on network error', async (t) => {
+  t.mock.method(console, 'debug', () => {})
+  setStorage({
+    maxConversationContextLength: 2,
+    maxResponseTokenLength: 128,
+    temperature: 0.1,
+  })
+
+  const session = {
+    modelName: 'customModel',
+    conversationRecords: [],
+    isRetry: false,
+  }
+  const port = createFakePort()
+
+  t.mock.method(globalThis, 'fetch', async () => {
+    throw new TypeError('Failed to fetch')
+  })
+
+  await assert.rejects(
+    () =>
+      generateAnswersWithCustomApi(
+        port,
+        'Q',
+        session,
+        'https://custom.api/v1/chat',
+        'key',
+        'model',
+      ),
+    /Failed to fetch/,
+  )
+
+  assert.deepEqual(port.listenerCounts(), { onMessage: 0, onDisconnect: 0 })
+})
+
+test('falls back to status text when JSON error parsing fails', async (t) => {
+  t.mock.method(console, 'debug', () => {})
+  setStorage({
+    maxConversationContextLength: 2,
+    maxResponseTokenLength: 128,
+    temperature: 0.1,
+  })
+
+  const session = {
+    modelName: 'customModel',
+    conversationRecords: [],
+    isRetry: false,
+  }
+  const port = createFakePort()
+
+  t.mock.method(globalThis, 'fetch', async () =>
+    createMockSseResponse([], {
+      ok: false,
+      status: 502,
+      statusText: 'Bad Gateway',
+      json: async () => {
+        throw new SyntaxError('Unexpected token')
+      },
+    }),
+  )
+
+  await assert.rejects(
+    () =>
+      generateAnswersWithCustomApi(
+        port,
+        'Q',
+        session,
+        'https://custom.api/v1/chat',
+        'key',
+        'model',
+      ),
+    /502 Bad Gateway/,
+  )
+
+  assert.deepEqual(port.listenerCounts(), { onMessage: 0, onDisconnect: 0 })
+})
+
+test('includes conversation history from prior records', async (t) => {
+  t.mock.method(console, 'debug', () => {})
+  setStorage({
+    maxConversationContextLength: 2,
+    maxResponseTokenLength: 128,
+    temperature: 0.1,
+  })
+
+  const session = {
+    modelName: 'customModel',
+    conversationRecords: [
+      { question: 'Q1', answer: 'A1' },
+      { question: 'Q2', answer: 'A2' },
+      { question: 'Q3', answer: 'A3' },
+    ],
+    isRetry: false,
+  }
+  const port = createFakePort()
+
+  let capturedInit
+  t.mock.method(globalThis, 'fetch', async (_input, init) => {
+    capturedInit = init
+    return createMockSseResponse([
+      'data: {"choices":[{"delta":{"content":"OK"},"finish_reason":"stop"}]}\n\n',
+    ])
+  })
+
+  await generateAnswersWithCustomApi(
+    port,
+    'Q4',
+    session,
+    'https://custom.api/v1/chat',
+    'key',
+    'model',
+  )
+
+  const body = JSON.parse(capturedInit.body)
+  // maxConversationContextLength=2 so only last 2 records are included + current question
+  assert.deepEqual(body.messages[0], { role: 'user', content: 'Q2' })
+  assert.deepEqual(body.messages[1], { role: 'assistant', content: 'A2' })
+  assert.deepEqual(body.messages[2], { role: 'user', content: 'Q3' })
+  assert.deepEqual(body.messages[3], { role: 'assistant', content: 'A3' })
+  assert.deepEqual(body.messages.at(-1), { role: 'user', content: 'Q4' })
+})
+
+test('retry mode overwrites last conversation record', async (t) => {
+  t.mock.method(console, 'debug', () => {})
+  setStorage({
+    maxConversationContextLength: 5,
+    maxResponseTokenLength: 128,
+    temperature: 0.1,
+  })
+
+  const session = {
+    modelName: 'customModel',
+    conversationRecords: [{ question: 'Q1', answer: 'old answer' }],
+    isRetry: true,
+  }
+  const port = createFakePort()
+
+  t.mock.method(globalThis, 'fetch', async () =>
+    createMockSseResponse([
+      'data: {"choices":[{"delta":{"content":"new answer"},"finish_reason":"stop"}]}\n\n',
+    ]),
+  )
+
+  await generateAnswersWithCustomApi(
+    port,
+    'Q1',
+    session,
+    'https://custom.api/v1/chat',
+    'key',
+    'model',
+  )
+
+  assert.equal(session.conversationRecords.length, 1)
+  assert.deepEqual(session.conversationRecords[0], { question: 'Q1', answer: 'new answer' })
+})
+
+test('delta.content with empty string is appended (no skip)', async (t) => {
+  t.mock.method(console, 'debug', () => {})
+  setStorage({
+    maxConversationContextLength: 2,
+    maxResponseTokenLength: 128,
+    temperature: 0.1,
+  })
+
+  const session = {
+    modelName: 'customModel',
+    conversationRecords: [],
+    isRetry: false,
+  }
+  const port = createFakePort()
+
+  t.mock.method(globalThis, 'fetch', async () =>
+    createMockSseResponse([
+      'data: {"choices":[{"delta":{"content":"A"}}]}\n\n',
+      'data: {"choices":[{"delta":{"content":""}}]}\n\n',
+      'data: {"choices":[{"delta":{"content":"B"},"finish_reason":"stop"}]}\n\n',
+    ]),
+  )
+
+  await generateAnswersWithCustomApi(
+    port,
+    'Q',
+    session,
+    'https://custom.api/v1/chat',
+    'key',
+    'model',
+  )
+
+  // After empty delta, answer should still be "A" (empty appended, not skipped)
+  const streaming = port.postedMessages.filter((m) => m.done === false)
+  assert.equal(streaming[0].answer, 'A')
+  assert.equal(streaming[1].answer, 'A') // "A" + "" = "A"
+  assert.equal(streaming[2].answer, 'AB')
+})

--- a/tests/unit/services/apis/thin-adapters.test.mjs
+++ b/tests/unit/services/apis/thin-adapters.test.mjs
@@ -1,0 +1,132 @@
+import assert from 'node:assert/strict'
+import { beforeEach, test } from 'node:test'
+import { createFakePort } from '../../helpers/port.mjs'
+import { createMockSseResponse } from '../../helpers/sse-response.mjs'
+
+import { generateAnswersWithAimlApi } from '../../../../src/services/apis/aiml-api.mjs'
+import { generateAnswersWithDeepSeekApi } from '../../../../src/services/apis/deepseek-api.mjs'
+import { generateAnswersWithMoonshotCompletionApi } from '../../../../src/services/apis/moonshot-api.mjs'
+import { generateAnswersWithOpenRouterApi } from '../../../../src/services/apis/openrouter-api.mjs'
+import { generateAnswersWithChatGLMApi } from '../../../../src/services/apis/chatglm-api.mjs'
+
+const setStorage = (values) => {
+  globalThis.__TEST_BROWSER_SHIM__.replaceStorage(values)
+}
+
+beforeEach(() => {
+  globalThis.__TEST_BROWSER_SHIM__.clearStorage()
+})
+
+const commonStorage = {
+  maxConversationContextLength: 3,
+  maxResponseTokenLength: 256,
+  temperature: 0.5,
+}
+
+const makeSession = () => ({
+  modelName: 'chatgptApi4oMini',
+  conversationRecords: [],
+  isRetry: false,
+})
+
+const sseChunks = ['data: {"choices":[{"delta":{"content":"OK"},"finish_reason":"stop"}]}\n\n']
+
+const adapters = [
+  {
+    name: 'aiml-api',
+    fn: (port, q, session) => generateAnswersWithAimlApi(port, q, session, 'aiml-key'),
+    expectedBaseUrl: 'https://api.aimlapi.com/v1',
+    expectedApiKey: 'aiml-key',
+    storage: commonStorage,
+  },
+  {
+    name: 'deepseek-api',
+    fn: (port, q, session) => generateAnswersWithDeepSeekApi(port, q, session, 'ds-key'),
+    expectedBaseUrl: 'https://api.deepseek.com',
+    expectedApiKey: 'ds-key',
+    storage: commonStorage,
+  },
+  {
+    name: 'moonshot-api',
+    fn: (port, q, session) => generateAnswersWithMoonshotCompletionApi(port, q, session, 'ms-key'),
+    expectedBaseUrl: 'https://api.moonshot.cn/v1',
+    expectedApiKey: 'ms-key',
+    storage: commonStorage,
+  },
+  {
+    name: 'openrouter-api',
+    fn: (port, q, session) => generateAnswersWithOpenRouterApi(port, q, session, 'or-key'),
+    expectedBaseUrl: 'https://openrouter.ai/api/v1',
+    expectedApiKey: 'or-key',
+    storage: commonStorage,
+  },
+  {
+    name: 'chatglm-api',
+    fn: (port, q, session) => generateAnswersWithChatGLMApi(port, q, session),
+    expectedBaseUrl: 'https://open.bigmodel.cn/api/paas/v4',
+    expectedApiKey: 'glm-key',
+    storage: { ...commonStorage, chatglmApiKey: 'glm-key' },
+  },
+]
+
+for (const adapter of adapters) {
+  test(`${adapter.name}: passes correct base URL and API key`, async (t) => {
+    t.mock.method(console, 'debug', () => {})
+    setStorage(adapter.storage)
+
+    const session = makeSession()
+    const port = createFakePort()
+
+    let capturedInput, capturedInit
+    t.mock.method(globalThis, 'fetch', async (input, init) => {
+      capturedInput = input
+      capturedInit = init
+      return createMockSseResponse(sseChunks)
+    })
+
+    await adapter.fn(port, 'Q', session)
+
+    assert.equal(capturedInput, `${adapter.expectedBaseUrl}/chat/completions`)
+    // Verify API key reaches the Authorization header
+    assert.equal(capturedInit.headers.Authorization, `Bearer ${adapter.expectedApiKey}`)
+  })
+
+  test(`${adapter.name}: delegates to compat layer and produces output`, async (t) => {
+    t.mock.method(console, 'debug', () => {})
+    setStorage(adapter.storage)
+
+    const session = makeSession()
+    const port = createFakePort()
+
+    t.mock.method(globalThis, 'fetch', async () => createMockSseResponse(sseChunks))
+
+    await adapter.fn(port, 'Q', session)
+
+    assert.equal(
+      port.postedMessages.some((m) => m.done === true && m.session === session),
+      true,
+    )
+    assert.deepEqual(session.conversationRecords.at(-1), {
+      question: 'Q',
+      answer: 'OK',
+    })
+  })
+}
+
+test('chatglm-api: reads chatglmApiKey from config', async (t) => {
+  t.mock.method(console, 'debug', () => {})
+  setStorage({ ...commonStorage, chatglmApiKey: 'glm-secret' })
+
+  const session = makeSession()
+  const port = createFakePort()
+
+  let capturedInit
+  t.mock.method(globalThis, 'fetch', async (_input, init) => {
+    capturedInit = init
+    return createMockSseResponse(sseChunks)
+  })
+
+  await generateAnswersWithChatGLMApi(port, 'Q', session)
+
+  assert.equal(capturedInit.headers.Authorization, 'Bearer glm-secret')
+})

--- a/tests/unit/services/init-session.test.mjs
+++ b/tests/unit/services/init-session.test.mjs
@@ -1,0 +1,111 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { initSession } from '../../../src/services/init-session.mjs'
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+test('initSession returns object with all required default/null fields', () => {
+  const session = initSession()
+
+  assert.equal(session.question, null)
+  assert.deepEqual(session.conversationRecords, [])
+  assert.equal(session.sessionName, null)
+  assert.equal(session.modelName, null)
+  assert.equal(session.apiMode, null)
+  assert.equal(session.autoClean, false)
+  assert.equal(session.isRetry, false)
+  assert.equal(session.aiName, null)
+})
+
+test('initSession generates a UUID v4 sessionId', () => {
+  const session = initSession()
+  assert.match(session.sessionId, UUID_RE)
+})
+
+test('initSession sets createdAt and updatedAt as ISO timestamps', () => {
+  const before = new Date().toISOString()
+  const session = initSession()
+  const after = new Date().toISOString()
+
+  assert.ok(session.createdAt >= before && session.createdAt <= after)
+  assert.ok(session.updatedAt >= before && session.updatedAt <= after)
+})
+
+test('initSession generates unique sessionIds', () => {
+  const a = initSession()
+  const b = initSession()
+  assert.notEqual(a.sessionId, b.sessionId)
+})
+
+test('initSession resolves aiName from modelName (not null)', () => {
+  const session = initSession({ modelName: 'claude2WebFree' })
+  assert.equal(session.modelName, 'claude2WebFree')
+  // aiName is derived via modelNameToDesc; exact value depends on i18next init
+  assert.notEqual(session.aiName, null)
+})
+
+test('initSession resolves aiName from apiMode (not null)', () => {
+  const apiMode = {
+    groupName: 'claude2WebFree',
+    itemName: 'claude2WebFree',
+    isCustom: false,
+    customName: '',
+    customUrl: '',
+    apiKey: '',
+    active: true,
+  }
+  const session = initSession({ apiMode })
+  assert.notEqual(session.aiName, null)
+})
+
+test('initSession aiName is null when no modelName and no apiMode', () => {
+  const session = initSession()
+  assert.equal(session.aiName, null)
+})
+
+test('initSession passes through provided question and sessionName', () => {
+  const session = initSession({ question: 'hello', sessionName: 'My Chat' })
+  assert.equal(session.question, 'hello')
+  assert.equal(session.sessionName, 'My Chat')
+})
+
+test('all provider-specific fields default to null', () => {
+  const session = initSession()
+
+  // chatgpt-web
+  assert.equal(session.conversationId, null)
+  assert.equal(session.messageId, null)
+  assert.equal(session.parentMessageId, null)
+  assert.equal(session.wsRequestId, null)
+
+  // bing
+  assert.equal(session.bingWeb_encryptedConversationSignature, null)
+  assert.equal(session.bingWeb_conversationId, null)
+  assert.equal(session.bingWeb_clientId, null)
+  assert.equal(session.bingWeb_invocationId, null)
+
+  // bing sydney
+  assert.equal(session.bingWeb_jailbreakConversationId, null)
+  assert.equal(session.bingWeb_parentMessageId, null)
+  assert.equal(session.bingWeb_jailbreakConversationCache, null)
+
+  // poe
+  assert.equal(session.poe_chatId, null)
+
+  // bard
+  assert.equal(session.bard_conversationObj, null)
+
+  // claude.ai
+  assert.equal(session.claude_conversation, null)
+
+  // kimi.com
+  assert.equal(session.moonshot_conversation, null)
+})
+
+test('initSession includes extraCustomModelName in aiName for customModel', () => {
+  const session = initSession({
+    modelName: 'customModel',
+    extraCustomModelName: 'my-special-model',
+  })
+  assert.ok(session.aiName.includes('my-special-model'))
+})

--- a/tests/unit/services/local-session.test.mjs
+++ b/tests/unit/services/local-session.test.mjs
@@ -1,0 +1,139 @@
+import assert from 'node:assert/strict'
+import { beforeEach, test } from 'node:test'
+import {
+  createSession,
+  deleteSession,
+  getSession,
+  getSessions,
+  resetSessions,
+  updateSession,
+} from '../../../src/services/local-session.mjs'
+import { initSession } from '../../../src/services/init-session.mjs'
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+beforeEach(() => {
+  globalThis.__TEST_BROWSER_SHIM__.clearStorage()
+})
+
+test('createSession without argument creates a new default session', async () => {
+  const { session, currentSessions } = await createSession()
+
+  assert.match(session.sessionId, UUID_RE)
+  // getSessions auto-initializes a reset session when storage is empty,
+  // so the result contains the new session plus the reset default
+  assert.ok(currentSessions.length >= 1)
+  assert.equal(currentSessions[0].sessionId, session.sessionId)
+})
+
+test('createSession with a session object inserts it', async () => {
+  const custom = initSession({ sessionName: 'Custom Chat' })
+  const { session, currentSessions } = await createSession(custom)
+
+  assert.equal(session.sessionName, 'Custom Chat')
+  assert.ok(currentSessions.length >= 1)
+  assert.equal(currentSessions[0].sessionId, custom.sessionId)
+})
+
+test('createSession upserts existing session by sessionId', async () => {
+  // Pre-seed storage so getSession finds the original
+  const original = initSession({ sessionName: 'Original' })
+  globalThis.__TEST_BROWSER_SHIM__.setStorage({ sessions: [original] })
+
+  const updated = { ...original, sessionName: 'Updated' }
+  const { session, currentSessions } = await createSession(updated)
+
+  assert.equal(session.sessionName, 'Updated')
+  assert.equal(currentSessions.length, 1)
+  assert.equal(currentSessions[0].sessionName, 'Updated')
+})
+
+test('deleteSession removes a session by id', async () => {
+  const s1 = initSession({ sessionName: 'First' })
+  const s2 = initSession({ sessionName: 'Second' })
+  // Pre-seed storage directly to avoid auto-initialization side effects
+  globalThis.__TEST_BROWSER_SHIM__.setStorage({ sessions: [s1, s2] })
+
+  const remaining = await deleteSession(s1.sessionId)
+  assert.equal(remaining.length, 1)
+  assert.equal(remaining[0].sessionId, s2.sessionId)
+})
+
+test('deleteSession resets when last session is removed', async () => {
+  const s = initSession({ sessionName: 'Only' })
+  // Directly seed storage with exactly one session to avoid auto-init side-effect
+  globalThis.__TEST_BROWSER_SHIM__.setStorage({ sessions: [s] })
+
+  const result = await deleteSession(s.sessionId)
+  // should trigger resetSessions() fallback and return a fresh default session
+  assert.equal(result.length, 1)
+  assert.notEqual(result[0].sessionId, s.sessionId)
+})
+
+test('resetSessions replaces all sessions with one default', async () => {
+  const s1 = initSession({ sessionName: 'A' })
+  const s2 = initSession({ sessionName: 'B' })
+  await createSession(s1)
+  await createSession(s2)
+
+  const result = await resetSessions()
+  assert.equal(result.length, 1)
+  assert.match(result[0].sessionId, UUID_RE)
+})
+
+test('getSessions initializes when storage is empty', async () => {
+  const sessions = await getSessions()
+
+  assert.equal(sessions.length, 1)
+  assert.match(sessions[0].sessionId, UUID_RE)
+})
+
+test('getSessions returns existing sessions from storage', async () => {
+  const s = initSession({ sessionName: 'Persisted' })
+  await createSession(s)
+
+  const sessions = await getSessions()
+  assert.ok(sessions.some((sess) => sess.sessionId === s.sessionId))
+})
+
+test('getSession finds session by id', async () => {
+  const s = initSession({ sessionName: 'Find Me' })
+  await createSession(s)
+
+  const { session } = await getSession(s.sessionId)
+  assert.equal(session.sessionId, s.sessionId)
+  assert.equal(session.sessionName, 'Find Me')
+})
+
+test('getSession returns undefined for non-existent id', async () => {
+  await createSession()
+  const { session } = await getSession('non-existent-id')
+  assert.equal(session, undefined)
+})
+
+test('updateSession sets updatedAt and persists changes', async () => {
+  const s = initSession({ sessionName: 'Before' })
+  await createSession(s)
+
+  const modified = { ...s, sessionName: 'After' }
+  const result = await updateSession(modified)
+
+  const found = result.find((sess) => sess.sessionId === s.sessionId)
+  assert.equal(found.sessionName, 'After')
+  assert.ok(found.updatedAt >= s.updatedAt)
+})
+
+test('storage persistence: data survives across calls', async () => {
+  const s = initSession({ sessionName: 'Persistent' })
+  await createSession(s)
+
+  // Retrieve via a separate getSessions call
+  const sessions = await getSessions()
+  const found = sessions.find((sess) => sess.sessionId === s.sessionId)
+  assert.equal(found.sessionName, 'Persistent')
+
+  // Verify raw storage
+  const raw = globalThis.__TEST_BROWSER_SHIM__.getStorage()
+  assert.ok(Array.isArray(raw.sessions))
+  assert.ok(raw.sessions.some((sess) => sess.sessionId === s.sessionId))
+})

--- a/tests/unit/services/wrappers-register.test.mjs
+++ b/tests/unit/services/wrappers-register.test.mjs
@@ -1,0 +1,399 @@
+import assert from 'node:assert/strict'
+import { beforeEach, test } from 'node:test'
+import { createFakePort } from '../helpers/port.mjs'
+
+// ---------------------------------------------------------------------------
+// Extend browser shim with onConnect and cookies before importing source
+// ---------------------------------------------------------------------------
+const onConnectListeners = new Set()
+globalThis.chrome.runtime.onConnect = {
+  addListener(listener) {
+    onConnectListeners.add(listener)
+  },
+  removeListener(listener) {
+    onConnectListeners.delete(listener)
+  },
+}
+
+let cookieJar = {}
+globalThis.chrome.cookies = {
+  getAll(query, callback) {
+    const result = cookieJar[query.url] || []
+    if (typeof callback === 'function') {
+      queueMicrotask(() => callback(result))
+      return
+    }
+    return Promise.resolve(result)
+  },
+  get(query, callback) {
+    const cookies = cookieJar[query.url] || []
+    const found = cookies.find((c) => c.name === query.name) || null
+    if (typeof callback === 'function') {
+      queueMicrotask(() => callback(found))
+      return
+    }
+    return Promise.resolve(found)
+  },
+}
+
+import {
+  registerPortListener,
+  getChatGptAccessToken,
+  getBingAccessToken,
+  getBardCookies,
+  getClaudeSessionKey,
+} from '../../../src/services/wrappers.mjs'
+
+const setStorage = (values) => {
+  globalThis.__TEST_BROWSER_SHIM__.replaceStorage(values)
+}
+
+function triggerConnect(port) {
+  for (const listener of Array.from(onConnectListeners)) {
+    listener(port)
+  }
+}
+
+beforeEach(() => {
+  globalThis.__TEST_BROWSER_SHIM__.clearStorage()
+  onConnectListeners.clear()
+  cookieJar = {}
+})
+
+// ---------------------------------------------------------------------------
+// registerPortListener
+// ---------------------------------------------------------------------------
+
+test('registerPortListener calls executor with session, port, and config', async (t) => {
+  t.mock.method(console, 'debug', () => {})
+  setStorage({ modelName: 'chatgptApi4oMini' })
+
+  let resolveExec
+  const execDone = new Promise((r) => {
+    resolveExec = r
+  })
+  const executor = t.mock.fn(async (session, port, config) => {
+    resolveExec({ session, port, config })
+  })
+
+  registerPortListener(executor)
+  const port = createFakePort()
+  triggerConnect(port)
+
+  port.emitMessage({ session: { conversationRecords: [] } })
+  const result = await execDone
+
+  assert.equal(executor.mock.calls.length, 1)
+  assert.equal(result.session.modelName, 'chatgptApi4oMini')
+  assert.ok(result.config)
+  // Session should be posted back before executor runs
+  assert.equal(port.postedMessages[0].session, result.session)
+})
+
+test('registerPortListener defaults modelName from config when not set', async (t) => {
+  t.mock.method(console, 'debug', () => {})
+  setStorage({ modelName: 'claude2Api' })
+
+  let resolveExec
+  const execDone = new Promise((r) => {
+    resolveExec = r
+  })
+  const executor = t.mock.fn(async (session) => {
+    resolveExec(session)
+  })
+
+  registerPortListener(executor)
+  const port = createFakePort()
+  triggerConnect(port)
+
+  port.emitMessage({ session: { conversationRecords: [] } })
+  const session = await execDone
+
+  assert.equal(session.modelName, 'claude2Api')
+})
+
+test('registerPortListener preserves modelName when already set', async (t) => {
+  t.mock.method(console, 'debug', () => {})
+  setStorage({ modelName: 'chatgptApi4oMini' })
+
+  let resolveExec
+  const execDone = new Promise((r) => {
+    resolveExec = r
+  })
+  const executor = t.mock.fn(async (session) => {
+    resolveExec(session)
+  })
+
+  registerPortListener(executor)
+  const port = createFakePort()
+  triggerConnect(port)
+
+  port.emitMessage({ session: { modelName: 'customModel', conversationRecords: [] } })
+  const session = await execDone
+
+  assert.equal(session.modelName, 'customModel')
+})
+
+test('registerPortListener skips apiMode default for customModel', async (t) => {
+  t.mock.method(console, 'debug', () => {})
+  setStorage({ modelName: 'customModel', apiMode: { groupName: 'openai', itemName: 'gpt-4o' } })
+
+  let resolveExec
+  const execDone = new Promise((r) => {
+    resolveExec = r
+  })
+  const executor = t.mock.fn(async (session) => {
+    resolveExec(session)
+  })
+
+  registerPortListener(executor)
+  const port = createFakePort()
+  triggerConnect(port)
+
+  port.emitMessage({ session: { modelName: 'customModel', conversationRecords: [] } })
+  const session = await execDone
+
+  assert.equal(session.apiMode, undefined)
+})
+
+test('registerPortListener defaults apiMode from config for non-custom models', async (t) => {
+  t.mock.method(console, 'debug', () => {})
+  const apiMode = { groupName: 'openai', itemName: 'gpt-4o' }
+  setStorage({ modelName: 'chatgptApi4oMini', apiMode })
+
+  let resolveExec
+  const execDone = new Promise((r) => {
+    resolveExec = r
+  })
+  const executor = t.mock.fn(async (session) => {
+    resolveExec(session)
+  })
+
+  registerPortListener(executor)
+  const port = createFakePort()
+  triggerConnect(port)
+
+  port.emitMessage({ session: { conversationRecords: [] } })
+  const session = await execDone
+
+  assert.deepEqual(session.apiMode, apiMode)
+})
+
+test('registerPortListener sets aiName when not provided', async (t) => {
+  t.mock.method(console, 'debug', () => {})
+  setStorage({ modelName: 'chatgptApi4oMini' })
+
+  let resolveExec
+  const execDone = new Promise((r) => {
+    resolveExec = r
+  })
+  const executor = t.mock.fn(async (session) => {
+    resolveExec(session)
+  })
+
+  registerPortListener(executor)
+  const port = createFakePort()
+  triggerConnect(port)
+
+  port.emitMessage({ session: { conversationRecords: [] } })
+  const session = await execDone
+
+  // aiName is assigned (t() may return undefined when i18next is not initialised)
+  assert.ok(Object.hasOwn(session, 'aiName'))
+})
+
+test('registerPortListener ignores messages without session', async (t) => {
+  t.mock.method(console, 'debug', () => {})
+  setStorage({ modelName: 'chatgptApi4oMini' })
+
+  const executor = t.mock.fn(async () => {})
+
+  registerPortListener(executor)
+  const port = createFakePort()
+  triggerConnect(port)
+
+  port.emitMessage({ notSession: true })
+  // Give the async handler a tick to process
+  await new Promise((r) => setTimeout(r, 50))
+
+  assert.equal(executor.mock.calls.length, 0)
+  assert.deepEqual(port.postedMessages, [])
+})
+
+test('registerPortListener catches executor errors and calls handlePortError', async (t) => {
+  t.mock.method(console, 'debug', () => {})
+  t.mock.method(console, 'error', () => {})
+  setStorage({ modelName: 'chatgptApi4oMini' })
+
+  let resolveExec
+  const execDone = new Promise((r) => {
+    resolveExec = r
+  })
+  const executor = t.mock.fn(async () => {
+    resolveExec()
+    throw new Error('executor boom')
+  })
+
+  registerPortListener(executor)
+  const port = createFakePort()
+  triggerConnect(port)
+
+  port.emitMessage({ session: { conversationRecords: [] } })
+  await execDone
+  // Give time for the catch block to run
+  await new Promise((r) => setTimeout(r, 50))
+
+  assert.equal(executor.mock.calls.length, 1)
+  // handlePortError should have posted an error message
+  assert.ok(port.postedMessages.some((m) => m.error === 'executor boom'))
+})
+
+test('registerPortListener removes listeners on port disconnect', async (t) => {
+  t.mock.method(console, 'debug', () => {})
+  setStorage({ modelName: 'chatgptApi4oMini' })
+
+  const executor = t.mock.fn(async () => {})
+
+  registerPortListener(executor)
+  const port = createFakePort()
+  triggerConnect(port)
+
+  // Port now has onMessage + onDisconnect listeners
+  assert.deepEqual(port.listenerCounts(), { onMessage: 1, onDisconnect: 1 })
+
+  port.emitDisconnect()
+
+  assert.deepEqual(port.listenerCounts(), { onMessage: 0, onDisconnect: 0 })
+})
+
+// ---------------------------------------------------------------------------
+// getChatGptAccessToken — cached token
+// ---------------------------------------------------------------------------
+
+test('getChatGptAccessToken returns cached token from config', async (t) => {
+  t.mock.method(console, 'debug', () => {})
+  setStorage({ accessToken: 'cached-token-123', tokenSavedOn: Date.now() })
+
+  const token = await getChatGptAccessToken()
+  assert.equal(token, 'cached-token-123')
+})
+
+// ---------------------------------------------------------------------------
+// getChatGptAccessToken — fetch from session endpoint
+// ---------------------------------------------------------------------------
+
+test('getChatGptAccessToken fetches token when not cached', async (t) => {
+  t.mock.method(console, 'debug', () => {})
+  setStorage({ tokenSavedOn: Date.now() })
+  cookieJar['https://chatgpt.com/'] = [
+    { name: 'session', value: 'abc' },
+    { name: 'cf', value: 'xyz' },
+  ]
+
+  t.mock.method(globalThis, 'fetch', async (url, init) => {
+    assert.equal(url, 'https://chatgpt.com/api/auth/session')
+    assert.equal(init.headers.Cookie, 'session=abc; cf=xyz')
+    return {
+      status: 200,
+      json: async () => ({ accessToken: 'fresh-token-456' }),
+    }
+  })
+
+  const token = await getChatGptAccessToken()
+  assert.equal(token, 'fresh-token-456')
+})
+
+test('getChatGptAccessToken throws CLOUDFLARE on 403', async (t) => {
+  t.mock.method(console, 'debug', () => {})
+  setStorage({ tokenSavedOn: Date.now() })
+  cookieJar['https://chatgpt.com/'] = []
+
+  t.mock.method(globalThis, 'fetch', async () => ({
+    status: 403,
+    json: async () => ({}),
+  }))
+
+  await assert.rejects(() => getChatGptAccessToken(), { message: 'CLOUDFLARE' })
+})
+
+test('getChatGptAccessToken throws UNAUTHORIZED when response has no token', async (t) => {
+  t.mock.method(console, 'debug', () => {})
+  setStorage({ tokenSavedOn: Date.now() })
+  cookieJar['https://chatgpt.com/'] = []
+
+  t.mock.method(globalThis, 'fetch', async () => ({
+    status: 200,
+    json: async () => ({}),
+  }))
+
+  await assert.rejects(() => getChatGptAccessToken(), { message: 'UNAUTHORIZED' })
+})
+
+test('getChatGptAccessToken throws UNAUTHORIZED when json parsing fails', async (t) => {
+  t.mock.method(console, 'debug', () => {})
+  setStorage({ tokenSavedOn: Date.now() })
+  cookieJar['https://chatgpt.com/'] = []
+
+  t.mock.method(globalThis, 'fetch', async () => ({
+    status: 200,
+    json: async () => {
+      throw new SyntaxError('bad json')
+    },
+  }))
+
+  await assert.rejects(() => getChatGptAccessToken(), { message: 'UNAUTHORIZED' })
+})
+
+// ---------------------------------------------------------------------------
+// getBingAccessToken
+// ---------------------------------------------------------------------------
+
+test('getBingAccessToken returns _U cookie value', async () => {
+  cookieJar['https://bing.com/'] = [{ name: '_U', value: 'bing-token' }]
+
+  const token = await getBingAccessToken()
+  assert.equal(token, 'bing-token')
+})
+
+test('getBingAccessToken returns undefined when cookie missing', async () => {
+  cookieJar['https://bing.com/'] = []
+
+  const token = await getBingAccessToken()
+  assert.equal(token, undefined)
+})
+
+// ---------------------------------------------------------------------------
+// getBardCookies
+// ---------------------------------------------------------------------------
+
+test('getBardCookies returns formatted cookie string', async () => {
+  cookieJar['https://google.com/'] = [{ name: '__Secure-1PSID', value: 'bard-sid' }]
+
+  const cookies = await getBardCookies()
+  assert.equal(cookies, '__Secure-1PSID=bard-sid')
+})
+
+test('getBardCookies returns __Secure-1PSID=undefined when cookie missing', async () => {
+  cookieJar['https://google.com/'] = []
+
+  const cookies = await getBardCookies()
+  assert.equal(cookies, '__Secure-1PSID=undefined')
+})
+
+// ---------------------------------------------------------------------------
+// getClaudeSessionKey
+// ---------------------------------------------------------------------------
+
+test('getClaudeSessionKey returns sessionKey cookie value', async () => {
+  cookieJar['https://claude.ai/'] = [{ name: 'sessionKey', value: 'sk-claude' }]
+
+  const key = await getClaudeSessionKey()
+  assert.equal(key, 'sk-claude')
+})
+
+test('getClaudeSessionKey returns undefined when cookie missing', async () => {
+  cookieJar['https://claude.ai/'] = []
+
+  const key = await getClaudeSessionKey()
+  assert.equal(key, undefined)
+})

--- a/tests/unit/utils/crop-text.test.mjs
+++ b/tests/unit/utils/crop-text.test.mjs
@@ -1,0 +1,195 @@
+import assert from 'node:assert/strict'
+import { beforeEach, test } from 'node:test'
+import { cropText } from '../../../src/utils/crop-text.mjs'
+
+beforeEach(() => {
+  globalThis.__TEST_BROWSER_SHIM__.clearStorage()
+})
+
+test('cropText returns text unchanged when shorter than limit', async () => {
+  globalThis.__TEST_BROWSER_SHIM__.replaceStorage({
+    cropText: true,
+    maxResponseTokenLength: 200,
+  })
+
+  const short = 'Hello world'
+  const result = await cropText(short, 8000, 800, 600, false)
+
+  assert.equal(result, short)
+})
+
+test('cropText returns text unchanged when cropText config is disabled', async () => {
+  globalThis.__TEST_BROWSER_SHIM__.replaceStorage({
+    cropText: false,
+  })
+
+  const text = 'This should be returned as-is regardless of length'
+  const result = await cropText(text, 10, 2, 2, false)
+
+  assert.equal(result, text)
+})
+
+test('cropText correctly splits on punctuation characters', async () => {
+  globalThis.__TEST_BROWSER_SHIM__.replaceStorage({
+    cropText: true,
+    maxResponseTokenLength: 200,
+    modelName: 'claude2WebFree',
+    apiMode: null,
+    customModelName: '',
+  })
+
+  // Build text with comma-separated segments that exceed maxLength (~7700 chars)
+  const segments = []
+  for (let i = 0; i < 2000; i++) {
+    segments.push(`segment${String(i).padStart(4, '0')}`)
+  }
+  const text = segments.join(',')
+
+  const result = await cropText(text, 8000, 800, 600, false)
+
+  // Result should be shorter than original since cropping happened
+  assert.ok(result.length < text.length, 'cropped text should be shorter than original')
+  // Result should still contain commas from splitting/reassembly
+  assert.ok(result.includes(','), 'result should contain commas from reassembly')
+})
+
+test('cropText preserves start and end portions of long text', async () => {
+  globalThis.__TEST_BROWSER_SHIM__.replaceStorage({
+    cropText: true,
+    maxResponseTokenLength: 200,
+    modelName: 'claude2WebFree',
+    apiMode: null,
+    customModelName: '',
+  })
+
+  // Create text with identifiable start/end markers separated by punctuation
+  const startPart = 'START'
+  const endPart = 'ENDMARKER'
+  const middleParts = []
+  for (let i = 0; i < 2000; i++) {
+    middleParts.push(`middle${String(i).padStart(4, '0')}`)
+  }
+  const text = startPart + ',' + middleParts.join(',') + ',' + endPart
+
+  const result = await cropText(text, 8000, 800, 600, false)
+
+  assert.ok(result.startsWith('START,'), 'result should start with START')
+  assert.ok(result.includes('ENDMARKER'), 'result should contain end marker')
+})
+
+test('cropText handles empty text input', async () => {
+  globalThis.__TEST_BROWSER_SHIM__.replaceStorage({
+    cropText: true,
+    maxResponseTokenLength: 100,
+  })
+
+  const result = await cropText('', 8000, 800, 600, false)
+
+  assert.equal(result, '')
+})
+
+test('cropText respects model-specific max lengths from model description', async () => {
+  // Set up config with a model whose desc contains a "128k" token size indicator
+  globalThis.__TEST_BROWSER_SHIM__.replaceStorage({
+    cropText: true,
+    modelName: 'chatgptApi4_128k',
+    apiMode: null,
+    maxResponseTokenLength: 2000,
+    customModelName: '',
+  })
+
+  // Build a very long text with punctuation separators (using char length mode)
+  const segments = []
+  for (let i = 0; i < 2000; i++) {
+    segments.push(`word${i}`)
+  }
+  const longText = segments.join(',')
+
+  const result = await cropText(longText, 8000, 800, 600, false)
+
+  // With a 128k model, the effective maxLength should be 128000 - 100 - 2000 = 125900
+  // which is far more than our text, so it should be returned as-is
+  assert.equal(result, longText)
+})
+
+test('cropText uses default maxLength when model desc has no k-token', async () => {
+  // claude2WebFree desc is "Claude.ai (Web)" — no Nk pattern
+  globalThis.__TEST_BROWSER_SHIM__.replaceStorage({
+    cropText: true,
+    modelName: 'claude2WebFree',
+    apiMode: null,
+    maxResponseTokenLength: 200,
+    customModelName: '',
+  })
+
+  const segments = []
+  for (let i = 0; i < 500; i++) {
+    segments.push(`seg${i}`)
+  }
+  const text = segments.join(',')
+
+  // With default maxLength=8000, minus 100+200=300 → effective ~7700 chars
+  // Our text is ~2500 chars so should be returned as-is
+  const result = await cropText(text, 8000, 800, 600, false)
+
+  assert.equal(result, text)
+})
+
+test('cropText internal clamp works at boundaries via maxResponseTokenLength', async () => {
+  // clamp(maxResponseTokenLength, 1, maxLength - 2000)
+  // With maxResponseTokenLength=0, clamped to 1 → maxLength = 8000 - 100 - 1 = 7899
+  // With a very large maxResponseTokenLength, clamped to maxLength-2000 → smaller budget
+  // We test with large maxResponseTokenLength that actually causes cropping
+  globalThis.__TEST_BROWSER_SHIM__.replaceStorage({
+    cropText: true,
+    maxResponseTokenLength: 7000,
+    modelName: 'claude2WebFree',
+    apiMode: null,
+    customModelName: '',
+  })
+
+  // Generate text long enough to trigger cropping with maxLength = 8000 - 100 - 5900 = 2000
+  const segments = []
+  for (let i = 0; i < 600; i++) segments.push(`word${i}`)
+  const longText = segments.join(',')
+
+  const result = await cropText(longText, 8000, 800, 600, false)
+  // maxLength = 2000, text is ~3600 chars, so cropping should occur
+  assert.ok(
+    result.length < longText.length,
+    'text should be cropped when maxResponseTokenLength is large',
+  )
+  assert.ok(result.length > 0, 'cropped text should not be empty')
+})
+
+test('cropText with tiktoken enabled processes text by token length', async () => {
+  globalThis.__TEST_BROWSER_SHIM__.replaceStorage({
+    cropText: true,
+    maxResponseTokenLength: 100,
+    modelName: 'claude2WebFree',
+    apiMode: null,
+    customModelName: '',
+  })
+
+  // Generate long text — each segment ~10 chars but ~2 tokens
+  // so token length < char length, causing different crop results
+  const segments = []
+  for (let i = 0; i < 2000; i++) segments.push(`segment${i}`)
+  const longText = segments.join(',')
+
+  // Use small maxLength (2000) to guarantee cropping in both modes
+  // Model desc 'Claude.ai (Web)' has no "Nk" pattern, so maxLength param is used directly
+  // Effective: 2000 - 100 - clamp(100,1,0) = 2000 - 100 - 1 = 1899
+  const resultTiktoken = await cropText(longText, 2000, 400, 300, true)
+  const resultChars = await cropText(longText, 2000, 400, 300, false)
+
+  // Both should be cropped
+  assert.ok(resultTiktoken.length < longText.length, 'tiktoken mode should crop')
+  assert.ok(resultChars.length < longText.length, 'char mode should crop')
+  // Token counting vs char counting should produce different results
+  assert.notEqual(
+    resultTiktoken.length,
+    resultChars.length,
+    'tiktoken and char modes should produce different crop lengths',
+  )
+})

--- a/tests/unit/utils/eventsource-parser.test.mjs
+++ b/tests/unit/utils/eventsource-parser.test.mjs
@@ -61,3 +61,115 @@ test('createParser ignores UTF-8 BOM in the first chunk', () => {
   assert.equal(parsed.length, 1)
   assert.equal(parsed[0].data, 'bom')
 })
+
+test('createParser handles \\r\\n line endings', () => {
+  const parsed = []
+  const parser = createParser((event) => parsed.push(event))
+
+  parser.feed(toBytes('data: hello\r\ndata: world\r\n\r\n'))
+
+  assert.equal(parsed.length, 1)
+  assert.equal(parsed[0].data, 'hello\nworld')
+})
+
+test('createParser handles \\r only line endings', () => {
+  const parsed = []
+  const parser = createParser((event) => parsed.push(event))
+
+  parser.feed(toBytes('data: solo\r\r'))
+
+  assert.equal(parsed.length, 1)
+  assert.equal(parsed[0].data, 'solo')
+})
+
+test('createParser ignores comment lines starting with colon', () => {
+  const parsed = []
+  const parser = createParser((event) => parsed.push(event))
+
+  parser.feed(toBytes(': this is a comment\ndata: actual\n\n'))
+
+  assert.equal(parsed.length, 1)
+  assert.equal(parsed[0].data, 'actual')
+})
+
+test('createParser handles data field with no space after colon', () => {
+  const parsed = []
+  const parser = createParser((event) => parsed.push(event))
+
+  parser.feed(toBytes('data:nospace\n\n'))
+
+  assert.equal(parsed.length, 1)
+  assert.equal(parsed[0].data, 'nospace')
+})
+
+test('createParser handles empty data field (colon only)', () => {
+  const parsed = []
+  const parser = createParser((event) => parsed.push(event))
+
+  parser.feed(toBytes('data:\n\n'))
+
+  assert.equal(parsed.length, 1)
+  assert.equal(parsed[0].data, '')
+})
+
+test('createParser ignores id field containing null byte', () => {
+  const parsed = []
+  const parser = createParser((event) => parsed.push(event))
+
+  parser.feed(toBytes('id: abc\0def\ndata: test\n\n'))
+
+  assert.equal(parsed.length, 1)
+  assert.equal(parsed[0].id, undefined)
+  assert.equal(parsed[0].data, 'test')
+})
+
+test('createParser handles field line without colon (noValue)', () => {
+  const parsed = []
+  const parser = createParser((event) => parsed.push(event))
+
+  parser.feed(toBytes('data\n\n'))
+
+  assert.equal(parsed.length, 1)
+  assert.equal(parsed[0].data, '')
+})
+
+test('createParser handles partial buffer after complete events', () => {
+  const parsed = []
+  const parser = createParser((event) => parsed.push(event))
+
+  parser.feed(toBytes('data: first\n\ndata: incom'))
+  assert.equal(parsed.length, 1)
+  assert.equal(parsed[0].data, 'first')
+
+  parser.feed(toBytes('plete\n\n'))
+  assert.equal(parsed.length, 2)
+  assert.equal(parsed[1].data, 'incomplete')
+})
+
+test('createParser strips BOM-like characters from decoded buffer', () => {
+  const parsed = []
+  const parser = createParser((event) => parsed.push(event))
+
+  // Construct bytes that decode to chars with charCodes [239, 187, 191] (ï»¿) followed by SSE data
+  const bomChars = new Uint8Array([195, 175, 194, 187, 194, 191])
+  const sseData = toBytes('data: after-bom\n\n')
+  const combined = new Uint8Array(bomChars.length + sseData.length)
+  combined.set(bomChars)
+  combined.set(sseData, bomChars.length)
+
+  parser.feed(combined)
+
+  assert.equal(parsed.length, 1)
+  assert.equal(parsed[0].data, 'after-bom')
+})
+
+test('createParser handles retry with non-numeric value', () => {
+  const parsed = []
+  const parser = createParser((event) => parsed.push(event))
+
+  parser.feed(toBytes('retry: notanumber\ndata: test\n\n'))
+
+  assert.equal(parsed.length, 1)
+  assert.equal(parsed[0].type, 'event')
+  assert.equal(parsed[0].data, 'test')
+})

--- a/tests/unit/utils/jwt-token-generator.test.mjs
+++ b/tests/unit/utils/jwt-token-generator.test.mjs
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import jwt from 'jsonwebtoken'
+
+// Module caches a single token globally; tests must use monotonically
+// increasing times so each test can force regeneration when needed.
+import { getToken } from '../../../src/utils/jwt-token-generator.mjs'
+
+test('getToken generates a valid JWT with correct header and payload structure', (t) => {
+  const now = 1_000_000_000_000
+  t.mock.method(Date, 'now', () => now)
+
+  const apiKey = 'my-kid.my-secret'
+  const token = getToken(apiKey)
+
+  const decoded = jwt.decode(token, { complete: true })
+  assert.equal(decoded.header.alg, 'HS256')
+  assert.equal(decoded.header.typ, 'JWT')
+  assert.equal(decoded.header.sign_type, 'SIGN')
+  assert.equal(decoded.payload.api_key, 'my-kid')
+  assert.equal(decoded.payload.timestamp, Math.floor(now / 1000))
+  assert.equal(decoded.payload.exp, Math.floor(now / 1000) + 86400)
+})
+
+test('getToken verifies with the secret from the API key', (t) => {
+  const now = 2_000_000_000_000
+  t.mock.method(Date, 'now', () => now)
+
+  const apiKey = 'kid123.supersecret'
+  const token = getToken(apiKey)
+
+  const verified = jwt.verify(token, 'supersecret')
+  assert.equal(verified.api_key, 'kid123')
+})
+
+test('getToken returns cached token when not expired', (t) => {
+  const now = 3_000_000_000_000
+  let currentTime = now
+  t.mock.method(Date, 'now', () => currentTime)
+
+  const apiKey = 'cache-kid.cache-secret'
+  const token1 = getToken(apiKey)
+
+  // Advance time by 1 hour (well within 24h expiry)
+  currentTime = now + 3600 * 1000
+  const token2 = getToken(apiKey)
+
+  assert.equal(token1, token2)
+})
+
+test('getToken regenerates token after expiration', (t) => {
+  const now = 4_000_000_000_000
+  let currentTime = now
+  t.mock.method(Date, 'now', () => currentTime)
+
+  const apiKey = 'regen-kid.regen-secret'
+  const token1 = getToken(apiKey)
+
+  // Advance time past the 24-hour expiry
+  currentTime = now + 86400 * 1000 + 1
+  const token2 = getToken(apiKey)
+
+  assert.notEqual(token1, token2)
+
+  const decoded = jwt.decode(token2)
+  assert.equal(decoded.timestamp, Math.floor(currentTime / 1000))
+})
+
+test('getToken throws on invalid API key format (no dot separator)', (t) => {
+  // Time past previous token's expiration to force regeneration attempt
+  t.mock.method(Date, 'now', () => 5_000_000_000_000)
+
+  assert.throws(() => getToken('no-dot-separator'), {
+    message: 'Invalid API key',
+  })
+})
+
+test('getToken throws on API key with multiple dots', (t) => {
+  // Previous test threw before updating cache, so cache still holds old expiry.
+  // Use time past all previous expirations.
+  t.mock.method(Date, 'now', () => 6_000_000_000_000)
+
+  assert.throws(() => getToken('too.many.dots'), {
+    message: 'Invalid API key',
+  })
+})

--- a/tests/unit/utils/model-name-convert.test.mjs
+++ b/tests/unit/utils/model-name-convert.test.mjs
@@ -3,9 +3,17 @@ import { test } from 'node:test'
 import {
   apiModeToModelName,
   getApiModesFromConfig,
+  getApiModesStringArrayFromConfig,
+  isApiModeSelected,
+  isInApiModeGroup,
   isUsingModelName,
   modelNameToApiMode,
+  modelNameToCustomPart,
+  modelNameToDesc,
+  modelNameToValue,
+  getModelValue,
 } from '../../../src/utils/model-name-convert.mjs'
+import { ModelGroups } from '../../../src/config/index.mjs'
 
 test('modelNameToApiMode and apiModeToModelName round-trip custom model names', () => {
   const modelName = 'bingFree4-fast'
@@ -102,4 +110,156 @@ test('isUsingModelName matches base model for custom model names', () => {
     active: true,
   }
   assert.equal(isUsingModelName('bingFree4', { apiMode }), true)
+})
+
+test('modelNameToDesc returns desc for a known model name without t function', () => {
+  const desc = modelNameToDesc('chatgptFree35')
+  assert.equal(desc, 'ChatGPT (Web)')
+})
+
+test('modelNameToDesc appends extraCustomModelName for customModel', () => {
+  const desc = modelNameToDesc('customModel', null, 'my-gpt')
+  assert.equal(desc, 'Custom Model (my-gpt)')
+})
+
+test('modelNameToDesc returns plain desc for customModel without extra name', () => {
+  const desc = modelNameToDesc('customModel')
+  assert.equal(desc, 'Custom Model')
+})
+
+test('modelNameToDesc handles custom model with presetPart in Models, customPart not in ModelMode', () => {
+  const desc = modelNameToDesc('chatgptFree35-myCustomSuffix')
+  assert.equal(desc, 'ChatGPT (Web) (myCustomSuffix)')
+})
+
+test('modelNameToDesc handles custom model with presetPart in ModelGroups', () => {
+  const desc = modelNameToDesc('bingWebModelKeys-customVariant')
+  assert.equal(desc, 'Bing (Web) (customVariant)')
+})
+
+test('modelNameToCustomPart returns modelName when not custom', () => {
+  assert.equal(modelNameToCustomPart('chatgptFree35'), 'chatgptFree35')
+})
+
+test('apiModeToModelName uses groupName prefix when itemName is custom', () => {
+  const apiMode = {
+    groupName: 'customApiModelKeys',
+    itemName: 'custom',
+    isCustom: true,
+    customName: 'my-endpoint',
+    customUrl: '',
+    apiKey: '',
+    active: true,
+  }
+  assert.equal(apiModeToModelName(apiMode), 'customApiModelKeys-my-endpoint')
+})
+
+test('getApiModesStringArrayFromConfig returns string model names', () => {
+  const config = {
+    activeApiModes: ['chatgptFree35'],
+    customApiModes: [],
+    azureDeploymentName: '',
+    ollamaModelName: '',
+  }
+  const result = getApiModesStringArrayFromConfig(config, false)
+  assert.ok(Array.isArray(result))
+  assert.ok(result.includes('chatgptFree35'))
+})
+
+test('isApiModeSelected matches via apiMode JSON comparison', () => {
+  const apiMode = {
+    groupName: 'bingWebModelKeys',
+    itemName: 'bingFree4',
+    isCustom: false,
+    customName: '',
+    customUrl: '',
+    apiKey: '',
+    active: true,
+  }
+  const configOrSession = { apiMode: { ...apiMode } }
+  assert.equal(isApiModeSelected(apiMode, configOrSession), true)
+
+  const different = { ...apiMode, itemName: 'bingFreeSydney' }
+  assert.equal(isApiModeSelected(different, configOrSession), false)
+})
+
+test('isApiModeSelected falls back to modelName when apiMode is absent', () => {
+  const apiMode = {
+    groupName: 'bingWebModelKeys',
+    itemName: 'bingFree4',
+    isCustom: false,
+    customName: '',
+    customUrl: '',
+    apiKey: '',
+    active: true,
+  }
+  assert.equal(isApiModeSelected(apiMode, { modelName: 'bingFree4' }), true)
+  assert.equal(isApiModeSelected(apiMode, { modelName: 'chatgptFree35' }), false)
+})
+
+test('isInApiModeGroup matches group via apiMode', () => {
+  const apiMode = {
+    groupName: 'bingWebModelKeys',
+    itemName: 'bingFree4',
+    isCustom: false,
+    customName: '',
+    customUrl: '',
+    apiKey: '',
+    active: true,
+  }
+  const bingGroup = ModelGroups.bingWebModelKeys.value
+  assert.equal(isInApiModeGroup(bingGroup, { apiMode }), true)
+})
+
+test('isInApiModeGroup matches group via modelName', () => {
+  const bingGroup = ModelGroups.bingWebModelKeys.value
+  assert.equal(isInApiModeGroup(bingGroup, { modelName: 'bingFree4' }), true)
+})
+
+test('isInApiModeGroup returns false when group not found', () => {
+  assert.equal(isInApiModeGroup(['nonexistent'], { modelName: 'totallyUnknown' }), false)
+})
+
+test('modelNameToValue returns value for known model', () => {
+  assert.equal(modelNameToValue('chatgptFree35'), 'auto')
+})
+
+test('modelNameToValue returns custom part for unknown model', () => {
+  assert.equal(modelNameToValue('bingFree4-fast'), 'fast')
+})
+
+test('getModelValue uses apiMode when present', () => {
+  const apiMode = {
+    groupName: 'bingWebModelKeys',
+    itemName: 'bingFree4',
+    isCustom: false,
+    customName: '',
+    customUrl: '',
+    apiKey: '',
+    active: true,
+  }
+  const value = getModelValue({ apiMode })
+  assert.equal(value, '')
+})
+
+test('getModelValue uses modelName when apiMode is absent', () => {
+  const value = getModelValue({ modelName: 'chatgptFree35' })
+  assert.equal(value, 'auto')
+})
+
+test('isUsingModelName returns true for exact apiMode match', () => {
+  const apiMode = {
+    groupName: 'chatgptApiModelKeys',
+    itemName: 'chatgptApi35',
+    isCustom: false,
+    customName: '',
+    customUrl: '',
+    apiKey: '',
+    active: true,
+  }
+  assert.equal(isUsingModelName('chatgptApi35', { apiMode }), true)
+})
+
+test('isUsingModelName resolves ModelGroups presetPart to first value', () => {
+  assert.equal(isUsingModelName('bingFree4', { modelName: 'bingWebModelKeys-custom' }), true)
 })


### PR DESCRIPTION
### **User description**
Add 172 tests (110 → 282) covering 14 new/extended test files.

Utilities & config:
- model-name-convert: extend to 100% (modelNameToDesc, getModelValue, isUsingModelName)
- eventsource-parser: extend to 100% (CR/LF, BOM, comments, partial buffers)
- crop-text: new tests for cropping, tiktoken paths, clamp behavior
- jwt-token-generator: new tests for generation, caching, expiry
- config predicates: complete isUsing* predicates + getPreferredLanguageKey

Content script:
- selection-tools: new tests for all 11 tools' genPrompt functions

Services & sessions:
- local-session: new CRUD tests (create, switch, delete, reset)
- init-session: new session shape validation tests
- wrappers/registerPortListener: new tests for port message flow, token getters

API adapters:
- custom-api: new tests for all response schemas, [DONE], finish_reason, errors
- azure-openai-api: new tests for URL composition, deployment fallback, headers
- claude-api: new tests for streaming, message_stop, header construction
- thin adapters (aiml, deepseek, moonshot, openrouter, chatglm): delegation + key forwarding

Background:
- Extract redactSensitiveFields to src/background/redact.mjs for testability
- New tests for sensitive key redaction, prompt/selection integration, depth limits

Bug fixes found during testing:
- custom-api.mjs: add optional chaining on data.choices (lines 79-81, 92) to prevent TypeError when APIs return {response} format without choices field (e.g. Ollama)


___

### **PR Type**
Tests, Bug fix


___

### **Description**
- Add 172 tests (110 → 282) across 14 new/extended test files
  - Custom API: 9 tests for response schemas, finish_reason, error handling
  - Azure OpenAI & Claude APIs: 8 tests each for URL composition, headers, streaming
  - Thin adapters (AIML, DeepSeek, Moonshot, OpenRouter, ChatGLM): delegation tests
  - Utilities: model-name-convert (100%), eventsource-parser (100%), crop-text, jwt-token-generator
  - Services: local-session CRUD, init-session validation, wrappers/registerPortListener
  - Content script: selection-tools genPrompt for all 11 tools
  - Background: redactSensitiveFields extraction with circular reference handling

- Fix optional chaining on `data.choices` in custom-api.mjs
  - Prevents TypeError when APIs return `{response}` format without choices field (e.g. Ollama)

- Extract `redactSensitiveFields` to `src/background/redact.mjs` for testability
  - Handles nested objects, arrays, circular references, depth limits


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Tests["14 Test Files<br/>172 New Tests"]
  Utils["Utils: model-name,<br/>eventsource, crop-text,<br/>jwt-token-generator"]
  Services["Services: local-session,<br/>init-session, wrappers"]
  APIs["APIs: custom, azure,<br/>claude, thin adapters"]
  Content["Content: selection-tools<br/>11 tools genPrompt"]
  Background["Background: redact<br/>sensitive fields"]
  BugFix["Bug Fix: optional<br/>chaining on choices"]
  
  Tests --> Utils
  Tests --> Services
  Tests --> APIs
  Tests --> Content
  Tests --> Background
  Background --> BugFix
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><details><summary>15 files</summary><table>
<tr>
  <td><strong>custom-api.test.mjs</strong><dd><code>Comprehensive custom API response schema tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ChatGPTBox-dev/chatGPTBox/pull/934/files#diff-f557f7fbc3d73f1a36c56841741855ea863b3a435e25b892f8b78279d28db98e">+556/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>wrappers-register.test.mjs</strong><dd><code>Port listener and token getter integration tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ChatGPTBox-dev/chatGPTBox/pull/934/files#diff-7e1036d0bb21c9978a3cc79740df282db64f08f93351534b44e52f0ceae5d003">+399/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>azure-openai-api.test.mjs</strong><dd><code>Azure OpenAI URL composition and header tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ChatGPTBox-dev/chatGPTBox/pull/934/files#diff-7467f08e8ad9ea37c244f75cc9628734dda28bdc5925b915d329f1006e563a0b">+261/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>claude-api.test.mjs</strong><dd><code>Claude API streaming and message_stop tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ChatGPTBox-dev/chatGPTBox/pull/934/files#diff-9205490b7b9e2ac91b215821833aceaa4989d11528681f6231265f3c2fc70abf">+254/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>crop-text.test.mjs</strong><dd><code>Text cropping with tiktoken and clamp behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ChatGPTBox-dev/chatGPTBox/pull/934/files#diff-7f95bb0836d42306ae1823378ca497d046f2e13b65797a8e09b5859226cb9d8e">+195/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>selection-tools.test.mjs</strong><dd><code>Selection tools genPrompt for all 11 tools</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ChatGPTBox-dev/chatGPTBox/pull/934/files#diff-a8ed0601c24b2aab9a38c003ac9046503cdbac9f09ff6751c28b1ce579ff7ba6">+188/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>model-name-convert.test.mjs</strong><dd><code>Extended model name conversion to 100% coverage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ChatGPTBox-dev/chatGPTBox/pull/934/files#diff-a41b643a38a6e9236f8bf70566d8a810431a7fddc93df3215f90e1dd7822fb75">+160/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>config-predicates.test.mjs</strong><dd><code>Complete isUsing* predicates for all providers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ChatGPTBox-dev/chatGPTBox/pull/934/files#diff-bfd96a829f986332e4c242ea5c5886ff9c5ad84ab73be32f216a19b957ccaad3">+113/-1</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>local-session.test.mjs</strong><dd><code>Session CRUD operations and persistence tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ChatGPTBox-dev/chatGPTBox/pull/934/files#diff-ac66291ad37b39dc5ad5df5d60acbde2be19d62c278abcb8c59e1405995b18cf">+139/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>thin-adapters.test.mjs</strong><dd><code>Thin adapter delegation and key forwarding tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ChatGPTBox-dev/chatGPTBox/pull/934/files#diff-4f944f6497607bba2eabb8ec8105a3c4467f2de9c6154cfbd1fa61d8fd907a9f">+132/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>redact.test.mjs</strong><dd><code>Sensitive field redaction and circular reference handling</code></dd></td>
  <td><a href="https://github.com/ChatGPTBox-dev/chatGPTBox/pull/934/files#diff-aae779829cb14b65d9ce6df88b2150d63b457c4049045ab3a8431b6499cfedfd">+110/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>eventsource-parser.test.mjs</strong><dd><code>Extended SSE parser coverage for edge cases</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ChatGPTBox-dev/chatGPTBox/pull/934/files#diff-88dece7d4b94a53e013782ef9d9fb65c0544da8ef36e94551e8fb2bf5488eb86">+112/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>init-session.test.mjs</strong><dd><code>Session initialization and shape validation tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ChatGPTBox-dev/chatGPTBox/pull/934/files#diff-aa14e62bcfc59a84fc7323a857eccc3f3394960b046e31c40059bc56a29886dc">+111/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>jwt-token-generator.test.mjs</strong><dd><code>JWT generation, caching, and expiry tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ChatGPTBox-dev/chatGPTBox/pull/934/files#diff-1f4795f7b1ed8afc858b17b301697c9629b39b7967e28eef64656cd2c1b97a64">+86/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>jsx-loader-hooks.mjs</strong><dd><code>ESM loader hooks for JSX and CJS interop</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ChatGPTBox-dev/chatGPTBox/pull/934/files#diff-090052e8285e8ef82a01ffb372f11abee9e83b6fad04188c58ef7ee14c519c45">+59/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>redact.mjs</strong><dd><code>Extract redactSensitiveFields for testability</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ChatGPTBox-dev/chatGPTBox/pull/934/files#diff-6a20f07f62b3e3b1999d6de18fe72b2588ff0b055fca9f09a71a3466b0c0e5c6">+73/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.mjs</strong><dd><code>Import redactSensitiveFields from redact module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ChatGPTBox-dev/chatGPTBox/pull/934/files#diff-9987a69b24893259cd32964b84b47fd3f151258f9cec9823025125f352df2b72">+1/-74</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>custom-api.mjs</strong><dd><code>Add optional chaining on data.choices access</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ChatGPTBox-dev/chatGPTBox/pull/934/files#diff-ed0979d1c89a77cc0b6c60b865b1f2e4f5217a4931ec8f4056381a283de66b02">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness when external API responses have missing or unexpected fields to avoid failures.

* **Quality & Stability**
  * Enhanced sensitive-data redaction across the app, including deeper handling of nested, circular, and overly deep structures.
  * Safer data access with additional guards against undefined response shapes.

* **Tests**
  * Vastly expanded unit test coverage across APIs, session handling, utilities, and parsing logic for greater reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->