### PR TITLE
Handle import errors in popup data restore

### DIFF
--- a/src/popup/sections/GeneralPart.jsx
+++ b/src/popup/sections/GeneralPart.jsx
@@ -568,13 +568,36 @@ export function GeneralPart({ config, updateConfig, setTabIndex }) {
               input.click()
             })
             if (!file) return
-            const data = await new Promise((resolve) => {
-              const reader = new FileReader()
-              reader.onload = (e) => resolve(JSON.parse(e.target.result))
-              reader.readAsText(file)
-            })
-            await importDataIntoStorage(Browser.storage.local, data)
-            window.location.reload()
+            try {
+              const fileContent =
+                typeof file.text === 'function'
+                  ? await file.text()
+                  : await new Promise((resolve, reject) => {
+                      const reader = new FileReader()
+                      reader.onload = () => resolve(reader.result)
+                      reader.onerror = () => reject(reader.error)
+                      reader.readAsText(file)
+                    })
+              const parsedData = JSON.parse(fileContent)
+              const isPlainObject =
+                parsedData !== null && typeof parsedData === 'object' && !Array.isArray(parsedData)
+
+              if (!isPlainObject) {
+                throw new Error('Invalid backup file')
+              }
+
+              await importDataIntoStorage(Browser.storage.local, parsedData)
+              window.location.reload()
+            } catch (error) {
+              console.error('[popup] Failed to import data', error)
+              const rawMessage =
+                error instanceof SyntaxError
+                  ? 'Invalid backup file'
+                  : error instanceof Error
+                  ? error.message
+                  : String(error ?? '')
+              window.alert(rawMessage ? `${t('Error')}: ${rawMessage}` : t('Error'))
+            }
           }}
         >
           {t('Import All Data')}


### PR DESCRIPTION
Wrap the popup import flow in a try/catch so file read, JSON parse, and storage errors no longer surface as unhandled promise rejections.

Keep the successful import path unchanged and show a simple user-facing error when restoring data fails.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chatgptbox-dev/chatgptbox/pull/956" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Import now rejects malformed or non-object files to prevent invalid data from being applied.
  * Improved import resilience with broader file-reading support and stricter validation.
  * Failures log clearer messages and display an internationalized alert with the error details.
  * Successful imports retain previous behavior and continue to trigger a full page refresh.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->