### PR TITLE
fix: accept sk-ant-sid02 session keys for claude web

### DIFF
--- a/src/services/clients/claude/index.mjs
+++ b/src/services/clients/claude/index.mjs
@@ -77,7 +77,6 @@ export class Claude {
     if (!/^sk-ant-sid\d+-/.test(sessionKey)) {
       throw new Error('Session key invalid: Must be in the format sk-ant-sidXX-*****')
     }
-    }
     if (fetch) {
       this.fetch = fetch
     }

--- a/src/services/clients/claude/index.mjs
+++ b/src/services/clients/claude/index.mjs
@@ -74,8 +74,8 @@ export class Claude {
     if (!sessionKey) {
       throw new Error('Session key required')
     }
-    if (!sessionKey.startsWith('sk-ant-sid01')) {
-      throw new Error('Session key invalid: Must be in the format sk-ant-sid01-*****')
+    if (!sessionKey.startsWith('sk-ant-sid')) {
+      throw new Error('Session key invalid: Must be in the format sk-ant-sid**-*****')
     }
     if (fetch) {
       this.fetch = fetch

--- a/src/services/clients/claude/index.mjs
+++ b/src/services/clients/claude/index.mjs
@@ -44,7 +44,7 @@ export class Claude {
    * @param {function} [options.fetch] - Fetch function
    * @example
    * const claude = new Claude({
-   *   sessionKey: 'sk-ant-sid01-*****',
+   *   sessionKey: 'sk-ant-sidXX-*****',
    *   fetch: globalThis.fetch
    * })
    *
@@ -164,7 +164,7 @@ export class Claude {
     // Can't figure out a way to test this so I'm just assuming it works
     if (!(this.fetch || globalThis.fetch)) {
       throw new Error(
-        `No fetch available in your environment. Use node-18 or later, a modern browser, or add the following code to your project:\n\nimport "isomorphic-fetch";\nconst claude = new Claude({fetch: fetch, sessionKey: "sk-ant-sid01-*****"});`,
+        `No fetch available in your environment. Use node-18 or later, a modern browser, or add the following code to your project:\n\nimport "isomorphic-fetch";\nconst claude = new Claude({fetch: fetch, sessionKey: "sk-ant-sidXX-*****"});`,
       )
     }
     if (!this.proxy) {

--- a/src/services/clients/claude/index.mjs
+++ b/src/services/clients/claude/index.mjs
@@ -74,8 +74,9 @@ export class Claude {
     if (!sessionKey) {
       throw new Error('Session key required')
     }
-    if (!sessionKey.startsWith('sk-ant-sid')) {
-      throw new Error('Session key invalid: Must be in the format sk-ant-sid**-*****')
+    if (!/^sk-ant-sid\d+-/.test(sessionKey)) {
+      throw new Error('Session key invalid: Must be in the format sk-ant-sidXX-*****')
+    }
     }
     if (fetch) {
       this.fetch = fetch

--- a/src/services/clients/claude/index.mjs
+++ b/src/services/clients/claude/index.mjs
@@ -44,7 +44,7 @@ export class Claude {
    * @param {function} [options.fetch] - Fetch function
    * @example
    * const claude = new Claude({
-   *   sessionKey: 'sk-ant-sidXX-*****',
+   *   sessionKey: 'sk-ant-sid02-*****',
    *   fetch: globalThis.fetch
    * })
    *
@@ -75,7 +75,7 @@ export class Claude {
       throw new Error('Session key required')
     }
     if (!/^sk-ant-sid\d+-/.test(sessionKey)) {
-      throw new Error('Session key invalid: Must be in the format sk-ant-sidXX-*****')
+      throw new Error('Session key invalid: Must be in the format sk-ant-sid02-*****')
     }
     if (fetch) {
       this.fetch = fetch
@@ -164,7 +164,7 @@ export class Claude {
     // Can't figure out a way to test this so I'm just assuming it works
     if (!(this.fetch || globalThis.fetch)) {
       throw new Error(
-        `No fetch available in your environment. Use node-18 or later, a modern browser, or add the following code to your project:\n\nimport "isomorphic-fetch";\nconst claude = new Claude({fetch: fetch, sessionKey: "sk-ant-sidXX-*****"});`,
+        `No fetch available in your environment. Use node-18 or later, a modern browser, or add the following code to your project:\n\nimport "isomorphic-fetch";\nconst claude = new Claude({fetch: fetch, sessionKey: "sk-ant-sid02-*****"});`,
       )
     }
     if (!this.proxy) {


### PR DESCRIPTION
Anthropic changed their session key format from `sk-ant-sid01-*` to `sk-ant-sid02-*`. The validation in `claude/index.mjs` was hardcoded to only accept `sid01`, causing an error for anyone with a newer key.
Changed the `startsWith` check from `sk-ant-sid01` to `sk-ant-sid` to accept any version going forward.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chatgptbox-dev/chatgptbox/pull/960" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Broadened session-key validation for the Claude service to accept a wider, variable key format and updated the invalid-key example shown in error/setup messages. This reduces false rejections and gives clearer guidance for correcting malformed keys.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ChatGPTBox-dev/chatGPTBox/pull/960?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->