### PR TITLE
fix: accept Claude session keys in sk-ant-sid02 format

### DIFF
--- a/src/services/clients/claude/index.mjs
+++ b/src/services/clients/claude/index.mjs
@@ -74,8 +74,8 @@ export class Claude {
     if (!sessionKey) {
       throw new Error('Session key required')
     }
-    if (!sessionKey.startsWith('sk-ant-sid01')) {
-      throw new Error('Session key invalid: Must be in the format sk-ant-sid01-*****')
+    if (!sessionKey.startsWith('sk-ant-sid')) {
+      throw new Error('Session key invalid: Must be in the format sk-ant-sid01-***** or sk-ant-sid02-*****')
     }
     if (fetch) {
       this.fetch = fetch

--- a/src/services/clients/claude/index.mjs
+++ b/src/services/clients/claude/index.mjs
@@ -74,8 +74,8 @@ export class Claude {
     if (!sessionKey) {
       throw new Error('Session key required')
     }
-    if (!sessionKey.startsWith('sk-ant-sid')) {
-      throw new Error('Session key invalid: Must be in the format sk-ant-sid01-***** or sk-ant-sid02-*****')
+    if (!/^sk-ant-sid\d+-/.test(sessionKey)) {
+      throw new Error('Session key invalid: Must be in the format sk-ant-sidNN-***** (e.g. sk-ant-sid01-*****, sk-ant-sid02-*****)')
     }
     if (fetch) {
       this.fetch = fetch


### PR DESCRIPTION
Fixes #935

## Problem

Anthropic has started issuing Claude Web session keys in the format `sk-ant-sid02-*****`, but the extension's Claude client validates keys strictly against the `sk-ant-sid01-` prefix. This causes users with new-format keys to see an error:

> Session key invalid: Must be in the format sk-ant-sid01-*****

## Solution

Relaxed the session key prefix check from `sk-ant-sid01` to `sk-ant-sid` so that it accepts both the `sid01` and `sid02` formats (and any future versioned formats Anthropic may introduce).

## Testing

- Verified the validation logic change in `src/services/clients/claude/index.mjs`
- `sk-ant-sid01-xxxxx` — still accepted ✓
- `sk-ant-sid02-xxxxx` — now accepted ✓
- Completely invalid keys (e.g. `invalid-key`) — still rejected ✓
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chatgptbox-dev/chatgptbox/pull/962" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded Claude client key validation to accept additional API key formats for improved compatibility.
  * Broadened validation error messaging to clearly describe accepted key format examples for easier troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->