### PR TITLE
fix(bilibili): filter null subtitle content to prevent literal 'null' strings in video summaries

### DIFF
--- a/src/content-script/site-adapters/bilibili/index.mjs
+++ b/src/content-script/site-adapters/bilibili/index.mjs
@@ -51,11 +51,10 @@ export default {
       const subtitleData = await subtitleResponse.json()
       const subtitles = subtitleData.body
 
-      let subtitleContent = ''
-      for (let i = 0; i < subtitles.length; i++) {
-        if (i === subtitles.length - 1) subtitleContent += subtitles[i].content
-        else subtitleContent += subtitles[i].content + ','
-      }
+      const subtitleContent = subtitles
+        .map((s) => s.content)
+        .filter((c) => c != null)
+        .join(',')
 
       return await cropText(
         `You are an expert video summarizer. Create a comprehensive summary of the following Bilibili video in markdown format, ` +


### PR DESCRIPTION
Fixes #893

## Problem

The Bilibili subtitle API sometimes returns entries with `null` content values. When these are concatenated into a string using JavaScript's `+` operator, `null` gets coerced to the literal string `"null"`, polluting the subtitle text sent to the AI model with large amounts of the word "null".

## Solution

Replace the manual `for` loop with `.map().filter().join()` to skip any subtitle entries where `content` is `null` or `undefined` before building the subtitle string:

```js
// Before
let subtitleContent = ''
for (let i = 0; i < subtitles.length; i++) {
  if (i === subtitles.length - 1) subtitleContent += subtitles[i].content
  else subtitleContent += subtitles[i].content + ','
}

// After
const subtitleContent = subtitles
  .map((s) => s.content)
  .filter((c) => c != null)
  .join(',')
```

## Testing

Reproduced by simulating a subtitle response with null-content entries; confirmed the old code produces `"null,null,actual text"` and the new code produces `"actual text"` only.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chatgptbox-dev/chatgptbox/pull/964" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subtitle handling to gracefully manage cases with missing or incomplete subtitle data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->