### PR TITLE
fix(wrappers): guard against undefined Browser.cookies in getChatGptAccessToken

### DIFF
--- a/src/services/wrappers.mjs
+++ b/src/services/wrappers.mjs
@@ -18,14 +18,15 @@ export async function getChatGptAccessToken() {
     let cookie = ''
     if (Browser.cookies && Browser.cookies.getAll) {
       cookie = (await Browser.cookies.getAll({ url: 'https://chatgpt.com/' }))
-        .map((cookie) => {
-          return `${cookie.name}=${cookie.value}`
+        .map(({ name, value }) => {
+          return `${name}=${value}`
         })
         .join('; ')
     }
     const resp = await fetch('https://chatgpt.com/api/auth/session', {
+      credentials: 'include',
       headers: {
-        Cookie: cookie,
+        ...(cookie && { Cookie: cookie }),
       },
     })
     if (resp.status === 403) {

--- a/src/services/wrappers.mjs
+++ b/src/services/wrappers.mjs
@@ -15,11 +15,14 @@ export async function getChatGptAccessToken() {
   if (userConfig.accessToken) {
     return userConfig.accessToken
   } else {
-    const cookie = (await Browser.cookies.getAll({ url: 'https://chatgpt.com/' }))
-      .map((cookie) => {
-        return `${cookie.name}=${cookie.value}`
-      })
-      .join('; ')
+    let cookie = ''
+    if (Browser.cookies && Browser.cookies.getAll) {
+      cookie = (await Browser.cookies.getAll({ url: 'https://chatgpt.com/' }))
+        .map((cookie) => {
+          return `${cookie.name}=${cookie.value}`
+        })
+        .join('; ')
+    }
     const resp = await fetch('https://chatgpt.com/api/auth/session', {
       headers: {
         Cookie: cookie,

--- a/tests/unit/services/wrappers-register.test.mjs
+++ b/tests/unit/services/wrappers-register.test.mjs
@@ -293,6 +293,7 @@ test('getChatGptAccessToken fetches token when not cached', async (t) => {
 
   t.mock.method(globalThis, 'fetch', async (url, init) => {
     assert.equal(url, 'https://chatgpt.com/api/auth/session')
+    assert.equal(init.credentials, 'include')
     assert.equal(init.headers.Cookie, 'session=abc; cf=xyz')
     return {
       status: 200,
@@ -349,7 +350,7 @@ test('getChatGptAccessToken throws UNAUTHORIZED when json parsing fails', async 
 // getChatGptAccessToken — Browser.cookies unavailable (issue #912)
 // ---------------------------------------------------------------------------
 
-test('getChatGptAccessToken sends empty Cookie header when Browser.cookies.getAll is unavailable', async (t) => {
+test('getChatGptAccessToken omits Cookie header when Browser.cookies.getAll is unavailable', async (t) => {
   t.mock.method(console, 'debug', () => {})
   setStorage({ tokenSavedOn: Date.now() })
 
@@ -370,10 +371,12 @@ test('getChatGptAccessToken sends empty Cookie header when Browser.cookies.getAl
     })
   })
 
-  let observedCookieHeader
+  let observedCredentials
+  let observedHasCookieHeader
   t.mock.method(globalThis, 'fetch', async (url, init) => {
     assert.equal(url, 'https://chatgpt.com/api/auth/session')
-    observedCookieHeader = init.headers.Cookie
+    observedCredentials = init.credentials
+    observedHasCookieHeader = Object.prototype.hasOwnProperty.call(init.headers, 'Cookie')
     return {
       status: 200,
       json: async () => ({ accessToken: 'token-without-cookies' }),
@@ -382,10 +385,12 @@ test('getChatGptAccessToken sends empty Cookie header when Browser.cookies.getAl
 
   const token = await getChatGptAccessToken()
   assert.equal(token, 'token-without-cookies')
-  assert.equal(observedCookieHeader, '')
+  // No empty Cookie header — let the browser attach session cookies via credentials: 'include'.
+  assert.equal(observedHasCookieHeader, false)
+  assert.equal(observedCredentials, 'include')
 })
 
-test('getChatGptAccessToken sends empty Cookie header when Browser.cookies is undefined', async (t) => {
+test('getChatGptAccessToken omits Cookie header when Browser.cookies is undefined', async (t) => {
   t.mock.method(console, 'debug', () => {})
   setStorage({ tokenSavedOn: Date.now() })
 
@@ -396,9 +401,11 @@ test('getChatGptAccessToken sends empty Cookie header when Browser.cookies is un
     Browser.cookies = originalCookies
   })
 
-  let observedCookieHeader
+  let observedCredentials
+  let observedHasCookieHeader
   t.mock.method(globalThis, 'fetch', async (url, init) => {
-    observedCookieHeader = init.headers.Cookie
+    observedCredentials = init.credentials
+    observedHasCookieHeader = Object.prototype.hasOwnProperty.call(init.headers, 'Cookie')
     return {
       status: 200,
       json: async () => ({ accessToken: 'token-no-cookies-api' }),
@@ -407,7 +414,8 @@ test('getChatGptAccessToken sends empty Cookie header when Browser.cookies is un
 
   const token = await getChatGptAccessToken()
   assert.equal(token, 'token-no-cookies-api')
-  assert.equal(observedCookieHeader, '')
+  assert.equal(observedHasCookieHeader, false)
+  assert.equal(observedCredentials, 'include')
 })
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/services/wrappers-register.test.mjs
+++ b/tests/unit/services/wrappers-register.test.mjs
@@ -43,6 +43,7 @@ import {
   getBardCookies,
   getClaudeSessionKey,
 } from '../../../src/services/wrappers.mjs'
+import Browser from 'webextension-polyfill'
 
 const setStorage = (values) => {
   globalThis.__TEST_BROWSER_SHIM__.replaceStorage(values)
@@ -342,6 +343,71 @@ test('getChatGptAccessToken throws UNAUTHORIZED when json parsing fails', async 
   }))
 
   await assert.rejects(() => getChatGptAccessToken(), { message: 'UNAUTHORIZED' })
+})
+
+// ---------------------------------------------------------------------------
+// getChatGptAccessToken — Browser.cookies unavailable (issue #912)
+// ---------------------------------------------------------------------------
+
+test('getChatGptAccessToken sends empty Cookie header when Browser.cookies.getAll is unavailable', async (t) => {
+  t.mock.method(console, 'debug', () => {})
+  setStorage({ tokenSavedOn: Date.now() })
+
+  // Simulate environments (e.g. some Firefox / restricted contexts) where
+  // chrome.cookies.getAll is not exposed. Override on the polyfill object
+  // and restore afterwards so other tests are unaffected.
+  const originalGetAll = Browser.cookies.getAll
+  Object.defineProperty(Browser.cookies, 'getAll', {
+    value: undefined,
+    writable: true,
+    configurable: true,
+  })
+  t.after(() => {
+    Object.defineProperty(Browser.cookies, 'getAll', {
+      value: originalGetAll,
+      writable: true,
+      configurable: true,
+    })
+  })
+
+  let observedCookieHeader
+  t.mock.method(globalThis, 'fetch', async (url, init) => {
+    assert.equal(url, 'https://chatgpt.com/api/auth/session')
+    observedCookieHeader = init.headers.Cookie
+    return {
+      status: 200,
+      json: async () => ({ accessToken: 'token-without-cookies' }),
+    }
+  })
+
+  const token = await getChatGptAccessToken()
+  assert.equal(token, 'token-without-cookies')
+  assert.equal(observedCookieHeader, '')
+})
+
+test('getChatGptAccessToken sends empty Cookie header when Browser.cookies is undefined', async (t) => {
+  t.mock.method(console, 'debug', () => {})
+  setStorage({ tokenSavedOn: Date.now() })
+
+  // Simulate environments where the cookies API is entirely missing.
+  const originalCookies = Browser.cookies
+  Browser.cookies = undefined
+  t.after(() => {
+    Browser.cookies = originalCookies
+  })
+
+  let observedCookieHeader
+  t.mock.method(globalThis, 'fetch', async (url, init) => {
+    observedCookieHeader = init.headers.Cookie
+    return {
+      status: 200,
+      json: async () => ({ accessToken: 'token-no-cookies-api' }),
+    }
+  })
+
+  const token = await getChatGptAccessToken()
+  assert.equal(token, 'token-no-cookies-api')
+  assert.equal(observedCookieHeader, '')
 })
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #912

## Problem

In some browser contexts (e.g. Safari, or environments where the `cookies` permission is unavailable), `Browser.cookies` can be `undefined`. The current `getChatGptAccessToken` implementation calls `Browser.cookies.getAll(...)` without checking if `Browser.cookies` exists, causing:

```
Error: can't access property "getAll", a.cookies is undefined
```

## Solution

Apply the same defensive guard pattern that already exists in `chatgpt-web.mjs` (line 255):

```js
// chatgpt-web.mjs (existing pattern)
if (Browser.cookies && Browser.cookies.getAll) {
  cookie = (await Browser.cookies.getAll(...))...
}
```

In `wrappers.mjs`, wrap the `Browser.cookies.getAll` call in the same guard, defaulting `cookie` to an empty string when cookies are unavailable. The session endpoint at `https://chatgpt.com/api/auth/session` is still fetched; it will return an `accessToken` if the browser already has a valid session established via `credentials: include` or other means.

## Testing

- Verified that the existing unit tests in `tests/unit/services/wrappers-register.test.mjs` still pass with this change.
- Confirmed the guard matches the existing pattern used elsewhere in the codebase.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chatgptbox-dev/chatgptbox/pull/965" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved authentication token handling so the app gracefully retrieves tokens in environments with limited or missing browser cookie support; requests omit Cookie headers when cookies aren't available.
* **Tests**
  * Added regression tests to ensure token retrieval still succeeds and that requests omit the Cookie header when cookie APIs are unavailable.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ChatGPTBox-dev/chatGPTBox/pull/965)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->