### PR TITLE
Add OpenAI's GPT-5.5 model

### DIFF
--- a/src/_locales/de/main.json
+++ b/src/_locales/de/main.json
@@ -199,5 +199,6 @@
   "OpenAI (GPT-5.4)": "OpenAI (GPT-5.4)",
   "OpenAI (GPT-5.4 mini)": "OpenAI (GPT-5.4 mini)",
   "OpenAI (GPT-5.4 nano)": "OpenAI (GPT-5.4 nano)",
+  "OpenAI (GPT-5.5)": "OpenAI (GPT-5.5)",
   "Anthropic (Claude Sonnet 4.6)": "Anthropic (Claude Sonnet 4.6)"
 }

--- a/src/_locales/en/main.json
+++ b/src/_locales/en/main.json
@@ -200,5 +200,6 @@
   "OpenAI (GPT-5.4)": "OpenAI (GPT-5.4)",
   "OpenAI (GPT-5.4 mini)": "OpenAI (GPT-5.4 mini)",
   "OpenAI (GPT-5.4 nano)": "OpenAI (GPT-5.4 nano)",
+  "OpenAI (GPT-5.5)": "OpenAI (GPT-5.5)",
   "Anthropic (Claude Sonnet 4.6)": "Anthropic (Claude Sonnet 4.6)"
 }

--- a/src/_locales/es/main.json
+++ b/src/_locales/es/main.json
@@ -199,5 +199,6 @@
   "OpenAI (GPT-5.4)": "OpenAI (GPT-5.4)",
   "OpenAI (GPT-5.4 mini)": "OpenAI (GPT-5.4 mini)",
   "OpenAI (GPT-5.4 nano)": "OpenAI (GPT-5.4 nano)",
+  "OpenAI (GPT-5.5)": "OpenAI (GPT-5.5)",
   "Anthropic (Claude Sonnet 4.6)": "Anthropic (Claude Sonnet 4.6)"
 }

--- a/src/_locales/fr/main.json
+++ b/src/_locales/fr/main.json
@@ -199,5 +199,6 @@
   "OpenAI (GPT-5.4)": "OpenAI (GPT-5.4)",
   "OpenAI (GPT-5.4 mini)": "OpenAI (GPT-5.4 mini)",
   "OpenAI (GPT-5.4 nano)": "OpenAI (GPT-5.4 nano)",
+  "OpenAI (GPT-5.5)": "OpenAI (GPT-5.5)",
   "Anthropic (Claude Sonnet 4.6)": "Anthropic (Claude Sonnet 4.6)"
 }

--- a/src/_locales/in/main.json
+++ b/src/_locales/in/main.json
@@ -199,5 +199,6 @@
   "OpenAI (GPT-5.4)": "OpenAI (GPT-5.4)",
   "OpenAI (GPT-5.4 mini)": "OpenAI (GPT-5.4 mini)",
   "OpenAI (GPT-5.4 nano)": "OpenAI (GPT-5.4 nano)",
+  "OpenAI (GPT-5.5)": "OpenAI (GPT-5.5)",
   "Anthropic (Claude Sonnet 4.6)": "Anthropic (Claude Sonnet 4.6)"
 }

--- a/src/_locales/it/main.json
+++ b/src/_locales/it/main.json
@@ -199,5 +199,6 @@
   "OpenAI (GPT-5.4)": "OpenAI (GPT-5.4)",
   "OpenAI (GPT-5.4 mini)": "OpenAI (GPT-5.4 mini)",
   "OpenAI (GPT-5.4 nano)": "OpenAI (GPT-5.4 nano)",
+  "OpenAI (GPT-5.5)": "OpenAI (GPT-5.5)",
   "Anthropic (Claude Sonnet 4.6)": "Anthropic (Claude Sonnet 4.6)"
 }

--- a/src/_locales/ja/main.json
+++ b/src/_locales/ja/main.json
@@ -199,5 +199,6 @@
   "OpenAI (GPT-5.4)": "OpenAI (GPT-5.4)",
   "OpenAI (GPT-5.4 mini)": "OpenAI (GPT-5.4 mini)",
   "OpenAI (GPT-5.4 nano)": "OpenAI (GPT-5.4 nano)",
+  "OpenAI (GPT-5.5)": "OpenAI (GPT-5.5)",
   "Anthropic (Claude Sonnet 4.6)": "Anthropic (Claude Sonnet 4.6)"
 }

--- a/src/_locales/ko/main.json
+++ b/src/_locales/ko/main.json
@@ -199,5 +199,6 @@
   "OpenAI (GPT-5.4)": "OpenAI (GPT-5.4)",
   "OpenAI (GPT-5.4 mini)": "OpenAI (GPT-5.4 mini)",
   "OpenAI (GPT-5.4 nano)": "OpenAI (GPT-5.4 nano)",
+  "OpenAI (GPT-5.5)": "OpenAI (GPT-5.5)",
   "Anthropic (Claude Sonnet 4.6)": "Anthropic (Claude Sonnet 4.6)"
 }

--- a/src/_locales/pt/main.json
+++ b/src/_locales/pt/main.json
@@ -199,5 +199,6 @@
   "OpenAI (GPT-5.4)": "OpenAI (GPT-5.4)",
   "OpenAI (GPT-5.4 mini)": "OpenAI (GPT-5.4 mini)",
   "OpenAI (GPT-5.4 nano)": "OpenAI (GPT-5.4 nano)",
+  "OpenAI (GPT-5.5)": "OpenAI (GPT-5.5)",
   "Anthropic (Claude Sonnet 4.6)": "Anthropic (Claude Sonnet 4.6)"
 }

--- a/src/_locales/ru/main.json
+++ b/src/_locales/ru/main.json
@@ -199,5 +199,6 @@
   "OpenAI (GPT-5.4)": "OpenAI (GPT-5.4)",
   "OpenAI (GPT-5.4 mini)": "OpenAI (GPT-5.4 mini)",
   "OpenAI (GPT-5.4 nano)": "OpenAI (GPT-5.4 nano)",
+  "OpenAI (GPT-5.5)": "OpenAI (GPT-5.5)",
   "Anthropic (Claude Sonnet 4.6)": "Anthropic (Claude Sonnet 4.6)"
 }

--- a/src/_locales/tr/main.json
+++ b/src/_locales/tr/main.json
@@ -199,5 +199,6 @@
   "OpenAI (GPT-5.4)": "OpenAI (GPT-5.4)",
   "OpenAI (GPT-5.4 mini)": "OpenAI (GPT-5.4 mini)",
   "OpenAI (GPT-5.4 nano)": "OpenAI (GPT-5.4 nano)",
+  "OpenAI (GPT-5.5)": "OpenAI (GPT-5.5)",
   "Anthropic (Claude Sonnet 4.6)": "Anthropic (Claude Sonnet 4.6)"
 }

--- a/src/_locales/zh-hans/main.json
+++ b/src/_locales/zh-hans/main.json
@@ -206,5 +206,6 @@
   "OpenAI (GPT-5.4)": "OpenAI (GPT-5.4)",
   "OpenAI (GPT-5.4 mini)": "OpenAI (GPT-5.4 mini)",
   "OpenAI (GPT-5.4 nano)": "OpenAI (GPT-5.4 nano)",
+  "OpenAI (GPT-5.5)": "OpenAI (GPT-5.5)",
   "Anthropic (Claude Sonnet 4.6)": "Anthropic (Claude Sonnet 4.6)"
 }

--- a/src/_locales/zh-hant/main.json
+++ b/src/_locales/zh-hant/main.json
@@ -201,5 +201,6 @@
   "OpenAI (GPT-5.4)": "OpenAI (GPT-5.4)",
   "OpenAI (GPT-5.4 mini)": "OpenAI (GPT-5.4 mini)",
   "OpenAI (GPT-5.4 nano)": "OpenAI (GPT-5.4 nano)",
+  "OpenAI (GPT-5.5)": "OpenAI (GPT-5.5)",
   "Anthropic (Claude Sonnet 4.6)": "Anthropic (Claude Sonnet 4.6)"
 }

--- a/src/config/index.mjs
+++ b/src/config/index.mjs
@@ -60,6 +60,7 @@ export const chatgptApiModelKeys = [
   'chatgptApi5_4',
   'chatgptApi5_4Mini',
   'chatgptApi5_4Nano',
+  'chatgptApi5_5',
   'chatgptApi4oMini',
   'chatgptApi4_8k',
   'chatgptApi4_8k_0613',
@@ -264,6 +265,7 @@ export const Models = {
   chatgptApi5_4: { value: 'gpt-5.4', desc: 'OpenAI (GPT-5.4)' },
   chatgptApi5_4Mini: { value: 'gpt-5.4-mini', desc: 'OpenAI (GPT-5.4 mini)' },
   chatgptApi5_4Nano: { value: 'gpt-5.4-nano', desc: 'OpenAI (GPT-5.4 nano)' },
+  chatgptApi5_5: { value: 'gpt-5.5', desc: 'OpenAI (GPT-5.5)' },
 
   chatgptApi4_1: { value: 'gpt-4.1', desc: 'OpenAI (GPT-4.1)' },
   chatgptApi4_1_mini: { value: 'gpt-4.1-mini', desc: 'OpenAI (GPT-4.1 mini)' },

--- a/tests/unit/config/config-predicates.test.mjs
+++ b/tests/unit/config/config-predicates.test.mjs
@@ -36,6 +36,7 @@ const representativeChatgptApiModelNames = [
   'chatgptApi5_4',
   'chatgptApi5_4Mini',
   'chatgptApi5_4Nano',
+  'chatgptApi5_5',
 ]
 const representativeGptCompletionApiModelNames = ['gptApiInstruct']
 const representativeClaudeApiModelNames = ['claude37SonnetApi', 'claudeOpus4Api']

--- a/tests/unit/services/apis/openai-token-params.test.mjs
+++ b/tests/unit/services/apis/openai-token-params.test.mjs
@@ -24,6 +24,7 @@ test('uses max_completion_tokens for recent gpt-5.x model names', () => {
     'gpt-5.3-chat-latest',
     'gpt-5.4-mini',
     'gpt-5.4-nano',
+    'gpt-5.5',
   ]
 
   for (const model of models) {

--- a/tests/unit/utils/model-name-convert.test.mjs
+++ b/tests/unit/utils/model-name-convert.test.mjs
@@ -125,6 +125,7 @@ test('modelNameToDesc returns desc for GPT-5 stable presets', () => {
   assert.equal(modelNameToDesc('chatgptApi5_4'), 'OpenAI (GPT-5.4)')
   assert.equal(modelNameToDesc('chatgptApi5_4Mini'), 'OpenAI (GPT-5.4 mini)')
   assert.equal(modelNameToDesc('chatgptApi5_4Nano'), 'OpenAI (GPT-5.4 nano)')
+  assert.equal(modelNameToDesc('chatgptApi5_5'), 'OpenAI (GPT-5.5)')
 })
 
 test('modelNameToDesc appends extraCustomModelName for customModel', () => {


### PR DESCRIPTION
Refs:

- https://developers.openai.com/api/docs/models/gpt-5.5
- https://developers.openai.com/api/docs/guides/latest-model
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chatgptbox-dev/chatgptbox/pull/966" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the OpenAI GPT-5.5 model, now available for selection in the interface with full localization support across 13 languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->