### PR TITLE
Format AIML representative model list

### DIFF
--- a/tests/unit/config/config-predicates.test.mjs
+++ b/tests/unit/config/config-predicates.test.mjs
@@ -43,10 +43,7 @@ const representativeOpenRouterApiModelNames = [
   'openRouter_anthropic_claude_sonnet4',
   'openRouter_openai_o3',
 ]
-const representativeAimlApiModelNames = [
-  'aiml_claude_sonnet_4_6_20260218',
-  'aiml_openai_gpt_5_2',
-]
+const representativeAimlApiModelNames = ['aiml_claude_sonnet_4_6_20260218', 'aiml_openai_gpt_5_2']
 
 const originalNavigatorDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'navigator')
 


### PR DESCRIPTION
Collapse the AIML representative model list to Prettier's single-line form so later commits do not pick up unrelated formatting churn.

The drift came from 0eb64f73, which refreshed the AIML model IDs but left the older multiline layout from ea210a9.

Reference:
- 0eb64f73 Refresh AIML default model presets
- ea210a9 Expand OpenAI model regression coverage
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chatgptbox-dev/chatgptbox/pull/967" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Reformatted test fixture for improved code consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->