### PR TITLE
Fix ConversationCard JSDoc indentation to match Prettier

### DIFF
--- a/src/components/ConversationCard/index.jsx
+++ b/src/components/ConversationCard/index.jsx
@@ -72,7 +72,7 @@ function ConversationCard(props) {
 
   /**
    * @type {[ConversationItemData[], (conversationItemData: ConversationItemData[]) => void]}
-  */
+   */
   const [conversationItemData, setConversationItemData] = useState([])
   const config = useConfig()
   const customOpenAIProviders = Array.isArray(config.customOpenAIProviders)


### PR DESCRIPTION
PR #930's commit `a8fff607` left the closing marker one space short, so pre-commit formatting kept surfacing this unrelated diff.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Internal code formatting improvements with no user-facing changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ChatGPTBox-dev/chatGPTBox/pull/974?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->