### PR TITLE
Add Claude Opus 4.8 support

### DIFF
--- a/src/_locales/de/main.json
+++ b/src/_locales/de/main.json
@@ -192,6 +192,7 @@
   "Anthropic (Claude Opus 4.1)": "Anthropic (Claude Opus 4.1)",
   "Anthropic (Claude Opus 4.5)": "Anthropic (Claude Opus 4.5)",
   "Anthropic (Claude Opus 4.6)": "Anthropic (Claude Opus 4.6)",
+  "Anthropic (Claude Opus 4.8)": "Anthropic (Claude Opus 4.8)",
   "Anthropic (Claude Sonnet 4)": "Anthropic (Claude Sonnet 4)",
   "Anthropic (Claude Sonnet 4.5)": "Anthropic (Claude Sonnet 4.5)",
   "Anthropic (Claude Haiku 4.5)": "Anthropic (Claude Haiku 4.5)",

--- a/src/_locales/en/main.json
+++ b/src/_locales/en/main.json
@@ -193,6 +193,7 @@
   "Anthropic (Claude Opus 4.1)": "Anthropic (Claude Opus 4.1)",
   "Anthropic (Claude Opus 4.5)": "Anthropic (Claude Opus 4.5)",
   "Anthropic (Claude Opus 4.6)": "Anthropic (Claude Opus 4.6)",
+  "Anthropic (Claude Opus 4.8)": "Anthropic (Claude Opus 4.8)",
   "Anthropic (Claude Sonnet 4)": "Anthropic (Claude Sonnet 4)",
   "Anthropic (Claude Sonnet 4.5)": "Anthropic (Claude Sonnet 4.5)",
   "Anthropic (Claude Haiku 4.5)": "Anthropic (Claude Haiku 4.5)",

--- a/src/_locales/es/main.json
+++ b/src/_locales/es/main.json
@@ -192,6 +192,7 @@
   "Anthropic (Claude Opus 4.1)": "Anthropic (Claude Opus 4.1)",
   "Anthropic (Claude Opus 4.5)": "Anthropic (Claude Opus 4.5)",
   "Anthropic (Claude Opus 4.6)": "Anthropic (Claude Opus 4.6)",
+  "Anthropic (Claude Opus 4.8)": "Anthropic (Claude Opus 4.8)",
   "Anthropic (Claude Sonnet 4)": "Anthropic (Claude Sonnet 4)",
   "Anthropic (Claude Sonnet 4.5)": "Anthropic (Claude Sonnet 4.5)",
   "Anthropic (Claude Haiku 4.5)": "Anthropic (Claude Haiku 4.5)",

--- a/src/_locales/fr/main.json
+++ b/src/_locales/fr/main.json
@@ -192,6 +192,7 @@
   "Anthropic (Claude Opus 4.1)": "Anthropic (Claude Opus 4.1)",
   "Anthropic (Claude Opus 4.5)": "Anthropic (Claude Opus 4.5)",
   "Anthropic (Claude Opus 4.6)": "Anthropic (Claude Opus 4.6)",
+  "Anthropic (Claude Opus 4.8)": "Anthropic (Claude Opus 4.8)",
   "Anthropic (Claude Sonnet 4)": "Anthropic (Claude Sonnet 4)",
   "Anthropic (Claude Sonnet 4.5)": "Anthropic (Claude Sonnet 4.5)",
   "Anthropic (Claude Haiku 4.5)": "Anthropic (Claude Haiku 4.5)",

--- a/src/_locales/in/main.json
+++ b/src/_locales/in/main.json
@@ -192,6 +192,7 @@
   "Anthropic (Claude Opus 4.1)": "Anthropic (Claude Opus 4.1)",
   "Anthropic (Claude Opus 4.5)": "Anthropic (Claude Opus 4.5)",
   "Anthropic (Claude Opus 4.6)": "Anthropic (Claude Opus 4.6)",
+  "Anthropic (Claude Opus 4.8)": "Anthropic (Claude Opus 4.8)",
   "Anthropic (Claude Sonnet 4)": "Anthropic (Claude Sonnet 4)",
   "Anthropic (Claude Sonnet 4.5)": "Anthropic (Claude Sonnet 4.5)",
   "Anthropic (Claude Haiku 4.5)": "Anthropic (Claude Haiku 4.5)",

--- a/src/_locales/it/main.json
+++ b/src/_locales/it/main.json
@@ -192,6 +192,7 @@
   "Anthropic (Claude Opus 4.1)": "Anthropic (Claude Opus 4.1)",
   "Anthropic (Claude Opus 4.5)": "Anthropic (Claude Opus 4.5)",
   "Anthropic (Claude Opus 4.6)": "Anthropic (Claude Opus 4.6)",
+  "Anthropic (Claude Opus 4.8)": "Anthropic (Claude Opus 4.8)",
   "Anthropic (Claude Sonnet 4)": "Anthropic (Claude Sonnet 4)",
   "Anthropic (Claude Sonnet 4.5)": "Anthropic (Claude Sonnet 4.5)",
   "Anthropic (Claude Haiku 4.5)": "Anthropic (Claude Haiku 4.5)",

--- a/src/_locales/ja/main.json
+++ b/src/_locales/ja/main.json
@@ -192,6 +192,7 @@
   "Anthropic (Claude Opus 4.1)": "Anthropic (Claude Opus 4.1)",
   "Anthropic (Claude Opus 4.5)": "Anthropic (Claude Opus 4.5)",
   "Anthropic (Claude Opus 4.6)": "Anthropic (Claude Opus 4.6)",
+  "Anthropic (Claude Opus 4.8)": "Anthropic (Claude Opus 4.8)",
   "Anthropic (Claude Sonnet 4)": "Anthropic (Claude Sonnet 4)",
   "Anthropic (Claude Sonnet 4.5)": "Anthropic (Claude Sonnet 4.5)",
   "Anthropic (Claude Haiku 4.5)": "Anthropic (Claude Haiku 4.5)",

--- a/src/_locales/ko/main.json
+++ b/src/_locales/ko/main.json
@@ -192,6 +192,7 @@
   "Anthropic (Claude Opus 4.1)": "Anthropic (Claude Opus 4.1)",
   "Anthropic (Claude Opus 4.5)": "Anthropic (Claude Opus 4.5)",
   "Anthropic (Claude Opus 4.6)": "Anthropic (Claude Opus 4.6)",
+  "Anthropic (Claude Opus 4.8)": "Anthropic (Claude Opus 4.8)",
   "Anthropic (Claude Sonnet 4)": "Anthropic (Claude Sonnet 4)",
   "Anthropic (Claude Sonnet 4.5)": "Anthropic (Claude Sonnet 4.5)",
   "Anthropic (Claude Haiku 4.5)": "Anthropic (Claude Haiku 4.5)",

--- a/src/_locales/pt/main.json
+++ b/src/_locales/pt/main.json
@@ -192,6 +192,7 @@
   "Anthropic (Claude Opus 4.1)": "Anthropic (Claude Opus 4.1)",
   "Anthropic (Claude Opus 4.5)": "Anthropic (Claude Opus 4.5)",
   "Anthropic (Claude Opus 4.6)": "Anthropic (Claude Opus 4.6)",
+  "Anthropic (Claude Opus 4.8)": "Anthropic (Claude Opus 4.8)",
   "Anthropic (Claude Sonnet 4)": "Anthropic (Claude Sonnet 4)",
   "Anthropic (Claude Sonnet 4.5)": "Anthropic (Claude Sonnet 4.5)",
   "Anthropic (Claude Haiku 4.5)": "Anthropic (Claude Haiku 4.5)",

--- a/src/_locales/ru/main.json
+++ b/src/_locales/ru/main.json
@@ -192,6 +192,7 @@
   "Anthropic (Claude Opus 4.1)": "Anthropic (Claude Opus 4.1)",
   "Anthropic (Claude Opus 4.5)": "Anthropic (Claude Opus 4.5)",
   "Anthropic (Claude Opus 4.6)": "Anthropic (Claude Opus 4.6)",
+  "Anthropic (Claude Opus 4.8)": "Anthropic (Claude Opus 4.8)",
   "Anthropic (Claude Sonnet 4)": "Anthropic (Claude Sonnet 4)",
   "Anthropic (Claude Sonnet 4.5)": "Anthropic (Claude Sonnet 4.5)",
   "Anthropic (Claude Haiku 4.5)": "Anthropic (Claude Haiku 4.5)",

--- a/src/_locales/tr/main.json
+++ b/src/_locales/tr/main.json
@@ -192,6 +192,7 @@
   "Anthropic (Claude Opus 4.1)": "Anthropic (Claude Opus 4.1)",
   "Anthropic (Claude Opus 4.5)": "Anthropic (Claude Opus 4.5)",
   "Anthropic (Claude Opus 4.6)": "Anthropic (Claude Opus 4.6)",
+  "Anthropic (Claude Opus 4.8)": "Anthropic (Claude Opus 4.8)",
   "Anthropic (Claude Sonnet 4)": "Anthropic (Claude Sonnet 4)",
   "Anthropic (Claude Sonnet 4.5)": "Anthropic (Claude Sonnet 4.5)",
   "Anthropic (Claude Haiku 4.5)": "Anthropic (Claude Haiku 4.5)",

--- a/src/_locales/zh-hans/main.json
+++ b/src/_locales/zh-hans/main.json
@@ -199,6 +199,7 @@
   "Anthropic (Claude Opus 4.1)": "Anthropic (Claude Opus 4.1)",
   "Anthropic (Claude Opus 4.5)": "Anthropic (Claude Opus 4.5)",
   "Anthropic (Claude Opus 4.6)": "Anthropic (Claude Opus 4.6)",
+  "Anthropic (Claude Opus 4.8)": "Anthropic (Claude Opus 4.8)",
   "Anthropic (Claude Sonnet 4)": "Anthropic (Claude Sonnet 4)",
   "Anthropic (Claude Sonnet 4.5)": "Anthropic (Claude Sonnet 4.5)",
   "Anthropic (Claude Haiku 4.5)": "Anthropic (Claude Haiku 4.5)",

--- a/src/_locales/zh-hant/main.json
+++ b/src/_locales/zh-hant/main.json
@@ -194,6 +194,7 @@
   "Anthropic (Claude Opus 4.1)": "Anthropic (Claude Opus 4.1)",
   "Anthropic (Claude Opus 4.5)": "Anthropic (Claude Opus 4.5)",
   "Anthropic (Claude Opus 4.6)": "Anthropic (Claude Opus 4.6)",
+  "Anthropic (Claude Opus 4.8)": "Anthropic (Claude Opus 4.8)",
   "Anthropic (Claude Sonnet 4)": "Anthropic (Claude Sonnet 4)",
   "Anthropic (Claude Sonnet 4.5)": "Anthropic (Claude Sonnet 4.5)",
   "Anthropic (Claude Haiku 4.5)": "Anthropic (Claude Haiku 4.5)",

--- a/src/config/index.mjs
+++ b/src/config/index.mjs
@@ -88,6 +88,7 @@ export const claudeApiModelKeys = [
   'claudeOpus41Api',
   'claudeOpus45Api',
   'claudeOpus46Api',
+  'claudeOpus48Api',
   'claudeSonnet4Api',
   'claudeSonnet45Api',
   'claudeSonnet46Api',
@@ -128,6 +129,7 @@ export const openRouterApiModelKeys = [
   'openRouter_anthropic_claude_sonnet4_5',
   'openRouter_anthropic_claude_opus4_5',
   'openRouter_anthropic_claude_opus4_6',
+  'openRouter_anthropic_claude_opus4_8',
   'openRouter_anthropic_claude_haiku4_5',
   'openRouter_anthropic_claude_3_7_sonnet',
   'openRouter_google_gemini_2_5_pro',
@@ -306,6 +308,10 @@ export const Models = {
     value: 'claude-opus-4-6',
     desc: 'Anthropic (Claude Opus 4.6)',
   },
+  claudeOpus48Api: {
+    value: 'claude-opus-4-8',
+    desc: 'Anthropic (Claude Opus 4.8)',
+  },
   claudeSonnet4Api: {
     value: 'claude-sonnet-4-20250514',
     desc: 'Anthropic (Claude Sonnet 4)',
@@ -417,6 +423,10 @@ export const Models = {
   openRouter_anthropic_claude_opus4_6: {
     value: 'anthropic/claude-opus-4.6',
     desc: 'OpenRouter (Claude Opus 4.6)',
+  },
+  openRouter_anthropic_claude_opus4_8: {
+    value: 'anthropic/claude-opus-4.8',
+    desc: 'OpenRouter (Claude Opus 4.8)',
   },
   openRouter_anthropic_claude_3_7_sonnet: {
     value: 'anthropic/claude-3.7-sonnet',


### PR DESCRIPTION
Expose Claude Opus 4.8 through the Anthropic API and OpenRouter model lists using the official model identifiers.

Add the matching Anthropic display label to each locale so the new API option renders consistently with existing Claude models.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Claude Opus 4.8 model support, available through both Anthropic and OpenRouter providers
  * Extended multilingual support to accommodate the new model across 12+ languages including German, Spanish, French, Indonesian, Italian, Japanese, Korean, Portuguese, Russian, Turkish, and Simplified and Traditional Chinese

<!-- end of auto-generated comment: release notes by coderabbit.ai -->