### PR TITLE
Omit temperature for Claude Opus 4.7 and 4.8

### DIFF
--- a/src/services/apis/claude-api.mjs
+++ b/src/services/apis/claude-api.mjs
@@ -5,6 +5,10 @@ import { isEmpty } from 'lodash-es'
 import { getConversationPairs } from '../../utils/get-conversation-pairs.mjs'
 import { getModelValue } from '../../utils/model-name-convert.mjs'
 
+function shouldOmitTemperature(model) {
+  return model === 'claude-opus-4-7' || model === 'claude-opus-4-8'
+}
+
 /**
  * @param {Runtime.Port} port
  * @param {string} question
@@ -22,6 +26,16 @@ export async function generateAnswersWithClaudeApi(port, question, session) {
   )
   prompt.push({ role: 'user', content: question })
 
+  const body = {
+    model,
+    messages: prompt,
+    stream: true,
+    max_tokens: config.maxResponseTokenLength,
+  }
+  if (!shouldOmitTemperature(model)) {
+    body.temperature = config.temperature
+  }
+
   let answer = ''
   await fetchSSE(`${apiUrl}/v1/messages`, {
     method: 'POST',
@@ -32,13 +46,7 @@ export async function generateAnswersWithClaudeApi(port, question, session) {
       'x-api-key': config.anthropicApiKey,
       'anthropic-dangerous-direct-browser-access': true,
     },
-    body: JSON.stringify({
-      model,
-      messages: prompt,
-      stream: true,
-      max_tokens: config.maxResponseTokenLength,
-      temperature: config.temperature,
-    }),
+    body: JSON.stringify(body),
     onMessage(message) {
       console.debug('sse message', message)
 

--- a/tests/unit/services/apis/claude-api.test.mjs
+++ b/tests/unit/services/apis/claude-api.test.mjs
@@ -84,6 +84,84 @@ test('claude-api: sends model, max_tokens, temperature in body', async (t) => {
   assert.equal(body.stream, true)
 })
 
+test('claude-api: keeps temperature for Opus 4.6', async (t) => {
+  t.mock.method(console, 'debug', () => {})
+  setStorage({
+    customClaudeApiUrl: 'https://api.anthropic.com',
+    claudeApiKey: 'sk-ant-test',
+    maxConversationContextLength: 3,
+    maxResponseTokenLength: 1024,
+    temperature: 0.9,
+  })
+
+  const session = {
+    modelName: 'claudeOpus46Api',
+    conversationRecords: [],
+    isRetry: false,
+  }
+  const port = createFakePort()
+
+  let capturedInit
+  t.mock.method(globalThis, 'fetch', async (_input, init) => {
+    capturedInit = init
+    return createMockSseResponse([
+      'data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"OK"}}\n\n',
+      'data: {"type":"message_stop"}\n\n',
+    ])
+  })
+
+  await generateAnswersWithClaudeApi(port, 'Q', session)
+
+  const body = JSON.parse(capturedInit.body)
+  assert.equal(body.model, 'claude-opus-4-6')
+  assert.equal(body.max_tokens, 1024)
+  assert.equal(body.temperature, 0.9)
+  assert.equal(body.stream, true)
+})
+
+test('claude-api: omits temperature for Opus 4.7 and 4.8', async (t) => {
+  t.mock.method(console, 'debug', () => {})
+
+  for (const [modelName, model] of [
+    ['claudeOpus47Api', 'claude-opus-4-7'],
+    ['claudeOpus48Api', 'claude-opus-4-8'],
+  ]) {
+    await t.test(modelName, async (t) => {
+      setStorage({
+        customClaudeApiUrl: 'https://api.anthropic.com',
+        claudeApiKey: 'sk-ant-test',
+        maxConversationContextLength: 3,
+        maxResponseTokenLength: 1024,
+        temperature: 0.9,
+      })
+
+      const session = {
+        modelName,
+        conversationRecords: [],
+        isRetry: false,
+      }
+      const port = createFakePort()
+
+      let capturedInit
+      t.mock.method(globalThis, 'fetch', async (_input, init) => {
+        capturedInit = init
+        return createMockSseResponse([
+          'data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"OK"}}\n\n',
+          'data: {"type":"message_stop"}\n\n',
+        ])
+      })
+
+      await generateAnswersWithClaudeApi(port, 'Q', session)
+
+      const body = JSON.parse(capturedInit.body)
+      assert.equal(body.model, model)
+      assert.equal(body.max_tokens, 1024)
+      assert.equal(body.stream, true)
+      assert.equal(Object.hasOwn(body, 'temperature'), false)
+    })
+  }
+})
+
 test('claude-api: delta.text streams accumulate and message_stop terminates', async (t) => {
   t.mock.method(console, 'debug', () => {})
   setStorage({


### PR DESCRIPTION
## Summary

- omit the Anthropic Claude API temperature field for Opus 4.7 and 4.8
- keep existing temperature behavior for other Claude models
- add tests for Opus 4.6, 4.7, and 4.8 request bodies

## Validation

- git diff --check
- npm test -- tests/unit/services/apis/claude-api.test.mjs
- npm test
- npm run lint
- npm run build
- coderabbit --agent
- claude -p code review prompt
- grok --always-approve -p code review prompt
- opencode run code review prompt
- kilo run --auto code review prompt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed API request handling for Claude Opus 4.7 and 4.8 models by correctly omitting the temperature parameter during API calls, ensuring proper model compatibility and request validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->