### PR TITLE
docs: mention Requesty as an OpenAI-compatible Custom Model option

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ English &nbsp;&nbsp;|&nbsp;&nbsp; [Indonesia](README_IN.md) &nbsp;&nbsp;|&nbsp;&
 
 - You can use projects like https://github.com/BerriAI/litellm / https://github.com/songquanpeng/one-api to convert LLM APIs into OpenAI format and use them in conjunction with ChatGPTBox's `Custom Model` mode
 
-- You can also use [Ollama](https://github.com/ChatGPTBox-dev/chatGPTBox/issues/616#issuecomment-1975186467) / https://openrouter.ai/docs#models with ChatGPTBox's `Custom Model` mode
+- You can also use [Ollama](https://github.com/ChatGPTBox-dev/chatGPTBox/issues/616#issuecomment-1975186467) / https://openrouter.ai/docs#models / [Requesty](https://requesty.ai/) with ChatGPTBox's `Custom Model` mode
 
 ## ✨ Features
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ English &nbsp;&nbsp;|&nbsp;&nbsp; [Indonesia](README_IN.md) &nbsp;&nbsp;|&nbsp;&
 
 - You can use projects like https://github.com/BerriAI/litellm / https://github.com/songquanpeng/one-api to convert LLM APIs into OpenAI format and use them in conjunction with ChatGPTBox's `Custom Model` mode
 
-- You can also use [Ollama](https://github.com/ChatGPTBox-dev/chatGPTBox/issues/616#issuecomment-1975186467) / https://openrouter.ai/docs#models / [Requesty](https://requesty.ai/) with ChatGPTBox's `Custom Model` mode
+- You can also use [Ollama](https://github.com/ChatGPTBox-dev/chatGPTBox/issues/616#issuecomment-1975186467) / [OpenRouter](https://openrouter.ai/docs#models) / [Requesty](https://requesty.ai/) with ChatGPTBox's `Custom Model` mode
 
 ## ✨ Features
 

--- a/README_IN.md
+++ b/README_IN.md
@@ -72,7 +72,7 @@ Integrasi Deep ChatGPT di browser Anda, sepenuhnya gratis.
 
 - Anda dapat menggunakan proyek seperti https://github.com/BerriAI/litellm / https://github.com/songquanpeng/one-api untuk mengkonversi API LLM ke dalam format OpenAI dan menggunakannya bersama dengan mode `Custom Model` dari ChatGPTBox
 
-- Anda juga dapat menggunakan [Ollama](https://github.com/ChatGPTBox-dev/chatGPTBox/issues/616#issuecomment-1975186467) / https://openrouter.ai/docs#models dengan mode `Custom Model` dari ChatGPTBox
+- Anda juga dapat menggunakan [Ollama](https://github.com/ChatGPTBox-dev/chatGPTBox/issues/616#issuecomment-1975186467) / https://openrouter.ai/docs#models / [Requesty](https://requesty.ai/) dengan mode `Custom Model` dari ChatGPTBox
 
 ## ✨ Fitur
 

--- a/README_IN.md
+++ b/README_IN.md
@@ -79,7 +79,7 @@ Integrasi Deep ChatGPT di browser Anda, sepenuhnya gratis.
 
 - Anda dapat menggunakan proyek seperti https://github.com/BerriAI/litellm / https://github.com/songquanpeng/one-api untuk mengkonversi API LLM ke dalam format OpenAI dan menggunakannya bersama dengan mode `Custom Model` dari ChatGPTBox
 
-- Anda juga dapat menggunakan [Ollama](https://github.com/ChatGPTBox-dev/chatGPTBox/issues/616#issuecomment-1975186467) / https://openrouter.ai/docs#models dengan mode `Custom Model` dari ChatGPTBox
+- Anda juga dapat menggunakan [Ollama](https://github.com/ChatGPTBox-dev/chatGPTBox/issues/616#issuecomment-1975186467) / https://openrouter.ai/docs#models / [Requesty](https://requesty.ai/) dengan mode `Custom Model` dari ChatGPTBox
 
 ## ✨ Fitur
 

--- a/README_IN.md
+++ b/README_IN.md
@@ -79,7 +79,7 @@ Integrasi Deep ChatGPT di browser Anda, sepenuhnya gratis.
 
 - Anda dapat menggunakan proyek seperti https://github.com/BerriAI/litellm / https://github.com/songquanpeng/one-api untuk mengkonversi API LLM ke dalam format OpenAI dan menggunakannya bersama dengan mode `Custom Model` dari ChatGPTBox
 
-- Anda juga dapat menggunakan [Ollama](https://github.com/ChatGPTBox-dev/chatGPTBox/issues/616#issuecomment-1975186467) / https://openrouter.ai/docs#models / [Requesty](https://requesty.ai/) dengan mode `Custom Model` dari ChatGPTBox
+- Anda juga dapat menggunakan [Ollama](https://github.com/ChatGPTBox-dev/chatGPTBox/issues/616#issuecomment-1975186467) / [OpenRouter](https://openrouter.ai/docs#models) / [Requesty](https://requesty.ai/) dengan mode `Custom Model` dari ChatGPTBox
 
 ## ✨ Fitur
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -74,7 +74,7 @@
 
 - https://github.com/BerriAI/litellm / https://github.com/songquanpeng/one-api のようなプロジェクトを使用して、LLM APIをOpenAI形式に変換し、それらをChatGPTBoxの `カスタムモデル` モードと組み合わせて使用することができます
 
-- もちろんです。ChatGPTBoxの `カスタムモデル` モードを使用する際には、[Ollama](https://github.com/ChatGPTBox-dev/chatGPTBox/issues/616#issuecomment-1975186467) / https://openrouter.ai/docs#models もご利用いただけます
+- もちろんです。ChatGPTBoxの `カスタムモデル` モードを使用する際には、[Ollama](https://github.com/ChatGPTBox-dev/chatGPTBox/issues/616#issuecomment-1975186467) / https://openrouter.ai/docs#models / [Requesty](https://requesty.ai/) もご利用いただけます
 
 ## ✨ 機能
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -79,7 +79,7 @@
 
 - https://github.com/BerriAI/litellm / https://github.com/songquanpeng/one-api のようなプロジェクトを使用して、LLM APIをOpenAI形式に変換し、それらをChatGPTBoxの `カスタムモデル` モードと組み合わせて使用することができます
 
-- ChatGPTBoxの `カスタムモデル` モードを使用する際には、[Ollama](https://github.com/ChatGPTBox-dev/chatGPTBox/issues/616#issuecomment-1975186467) / https://openrouter.ai/docs#models / [Requesty](https://requesty.ai/) もご利用いただけます
+- ChatGPTBoxの `カスタムモデル` モードを使用する際には、[Ollama](https://github.com/ChatGPTBox-dev/chatGPTBox/issues/616#issuecomment-1975186467) / [OpenRouter](https://openrouter.ai/docs#models) / [Requesty](https://requesty.ai/) もご利用いただけます
 
 ## ✨ 機能
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -79,7 +79,7 @@
 
 - https://github.com/BerriAI/litellm / https://github.com/songquanpeng/one-api のようなプロジェクトを使用して、LLM APIをOpenAI形式に変換し、それらをChatGPTBoxの `カスタムモデル` モードと組み合わせて使用することができます
 
-- ChatGPTBoxの `カスタムモデル` モードを使用する際には、[Ollama](https://github.com/ChatGPTBox-dev/chatGPTBox/issues/616#issuecomment-1975186467) / https://openrouter.ai/docs#models もご利用いただけます
+- ChatGPTBoxの `カスタムモデル` モードを使用する際には、[Ollama](https://github.com/ChatGPTBox-dev/chatGPTBox/issues/616#issuecomment-1975186467) / https://openrouter.ai/docs#models / [Requesty](https://requesty.ai/) もご利用いただけます
 
 ## ✨ 機能
 

--- a/README_TR.md
+++ b/README_TR.md
@@ -75,7 +75,7 @@ Tarayıcınıza derin ChatGPT entegrasyonu, tamamen ücretsiz.
 
 - Proje olarak https://github.com/BerriAI/litellm / https://github.com/songquanpeng/one-api gibi şeyleri kullanarak LLM API'larını OpenAI formatına dönüştürebilir ve bunları ChatGPTBox'ın `Custom Model` modu ile birlikte kullanabilirsiniz
 
-- ChatGPTBox'un `Custom Model` modu ile [Ollama](https://github.com/ChatGPTBox-dev/chatGPTBox/issues/616#issuecomment-1975186467) / https://openrouter.ai/docs#models adresini de kullanabilirsiniz
+- ChatGPTBox'un `Custom Model` modu ile [Ollama](https://github.com/ChatGPTBox-dev/chatGPTBox/issues/616#issuecomment-1975186467) / https://openrouter.ai/docs#models / [Requesty](https://requesty.ai/) adresini de kullanabilirsiniz
 
 ## ✨ Özellikler
 

--- a/README_TR.md
+++ b/README_TR.md
@@ -80,7 +80,7 @@ Tarayıcınıza derin ChatGPT entegrasyonu, tamamen ücretsiz.
 
 - Proje olarak https://github.com/BerriAI/litellm / https://github.com/songquanpeng/one-api gibi şeyleri kullanarak LLM API'larını OpenAI formatına dönüştürebilir ve bunları ChatGPTBox'ın `Custom Model` modu ile birlikte kullanabilirsiniz
 
-- ChatGPTBox'un `Custom Model` modu ile [Ollama](https://github.com/ChatGPTBox-dev/chatGPTBox/issues/616#issuecomment-1975186467) / https://openrouter.ai/docs#models / [Requesty](https://requesty.ai/) adresini de kullanabilirsiniz
+- ChatGPTBox'un `Custom Model` modu ile [Ollama](https://github.com/ChatGPTBox-dev/chatGPTBox/issues/616#issuecomment-1975186467) / [OpenRouter](https://openrouter.ai/docs#models) / [Requesty](https://requesty.ai/) adresini de kullanabilirsiniz
 
 ## ✨ Özellikler
 

--- a/README_TR.md
+++ b/README_TR.md
@@ -80,7 +80,7 @@ Tarayıcınıza derin ChatGPT entegrasyonu, tamamen ücretsiz.
 
 - Proje olarak https://github.com/BerriAI/litellm / https://github.com/songquanpeng/one-api gibi şeyleri kullanarak LLM API'larını OpenAI formatına dönüştürebilir ve bunları ChatGPTBox'ın `Custom Model` modu ile birlikte kullanabilirsiniz
 
-- ChatGPTBox'un `Custom Model` modu ile [Ollama](https://github.com/ChatGPTBox-dev/chatGPTBox/issues/616#issuecomment-1975186467) / https://openrouter.ai/docs#models adresini de kullanabilirsiniz
+- ChatGPTBox'un `Custom Model` modu ile [Ollama](https://github.com/ChatGPTBox-dev/chatGPTBox/issues/616#issuecomment-1975186467) / https://openrouter.ai/docs#models / [Requesty](https://requesty.ai/) adresini de kullanabilirsiniz
 
 ## ✨ Özellikler
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -81,7 +81,7 @@
 
 - 对于国内用户, 有GPT, Midjourney, Netflix等账号需求的, 可以考虑此站点购买合租, 此链接购买的订单也会给我带来一定收益, 作为对本项目的支持: https://nf.video/yinhe/web?sharedId=84599
 
-- 三方API服务兼容, 查看 https://api2d.com/r/193934 和 https://openrouter.ai/docs#models, 该服务并不是由我提供的, 但对于获取账号困难的用户可以考虑, 使用方法: [视频](https://www.bilibili.com/video/BV1bo4y1h7Hb/) [图文](https://github.com/ChatGPTBox-dev/chatGPTBox/issues/166#issuecomment-1504704489)
+- 三方API服务兼容, 查看 https://api2d.com/r/193934 和 [OpenRouter](https://openrouter.ai/docs#models) / [Requesty](https://requesty.ai/), 该服务并不是由我提供的, 但对于获取账号困难的用户可以考虑, 使用方法: [视频](https://www.bilibili.com/video/BV1bo4y1h7Hb/) [图文](https://github.com/ChatGPTBox-dev/chatGPTBox/issues/166#issuecomment-1504704489)
 
 - 离线/自托管模型 现已支持, 在`自定义模型`模式下使用, 具体查看 [Ollama](https://github.com/ChatGPTBox-dev/chatGPTBox/issues/616#issuecomment-1975186467) / [RWKV-Runner](https://github.com/josStorer/RWKV-Runner), 你还可以部署wenda (https://github.com/wenda-LLM/wenda), 配合自定义模型模式使用, 从而调用各类本地模型, 参考 [#397](https://github.com/ChatGPTBox-dev/chatGPTBox/issues/397) 修改API URL
 


### PR DESCRIPTION
This adds a short mention of Requesty alongside the existing OpenRouter mention for ChatGPTBox's `Custom Model` mode.

Requesty is an OpenAI-compatible LLM gateway, so it works with the `Custom Model` mode the same way OpenRouter does:
- Base URL: https://router.requesty.ai/v1
- Model naming: provider/model (e.g. openai/gpt-4o-mini)

I verified a live chat completion against https://router.requesty.ai/v1 using model openai/gpt-4o-mini (HTTP 200, valid completion returned) before opening this PR.

The mention was added to the parallel Custom Model line in README.md and the matching localized lines in README_JA.md, README_IN.md, and README_TR.md.

Links:
- https://requesty.ai
- https://docs.requesty.ai

I work at Requesty. This mirrors the existing OpenRouter mention as closely as possible. Happy to adjust or close it if it's not a fit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated English, Indonesian, Japanese, Turkish, and Chinese documentation to include Requesty among the available Custom Model or third-party API service options.
  * Added or updated provider links, including a linked OpenRouter reference in the Japanese documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->