### PR TITLE
Add Anthropic Claude Sonnet 5 API support

### DIFF
--- a/src/config/index.mjs
+++ b/src/config/index.mjs
@@ -83,6 +83,7 @@ export const claudeApiModelKeys = [
   'claudeOpus48Api',
   'claudeSonnet45Api',
   'claudeSonnet46Api',
+  'claudeSonnet5Api',
   'claudeHaiku45Api',
 ]
 export const chatglmApiModelKeys = [
@@ -317,6 +318,10 @@ export const Models = {
   claudeSonnet46Api: {
     value: 'claude-sonnet-4-6',
     desc: 'Anthropic (Claude Sonnet 4.6)',
+  },
+  claudeSonnet5Api: {
+    value: 'claude-sonnet-5',
+    desc: 'Anthropic (Claude Sonnet 5)',
   },
   claudeHaiku45Api: {
     value: 'claude-haiku-4-5-20251001',

--- a/src/services/apis/claude-api.mjs
+++ b/src/services/apis/claude-api.mjs
@@ -6,7 +6,11 @@ import { getConversationPairs } from '../../utils/get-conversation-pairs.mjs'
 import { getModelValue } from '../../utils/model-name-convert.mjs'
 
 function shouldOmitTemperature(model) {
-  return model === 'claude-opus-4-7' || model === 'claude-opus-4-8'
+  return model === 'claude-opus-4-7' || model === 'claude-opus-4-8' || model === 'claude-sonnet-5'
+}
+
+function shouldDisableDefaultThinking(model) {
+  return model === 'claude-sonnet-5'
 }
 
 /**
@@ -31,6 +35,9 @@ export async function generateAnswersWithClaudeApi(port, question, session) {
     messages: prompt,
     stream: true,
     max_tokens: config.maxResponseTokenLength,
+  }
+  if (shouldDisableDefaultThinking(model)) {
+    body.thinking = { type: 'disabled' }
   }
   if (!shouldOmitTemperature(model)) {
     body.temperature = config.temperature

--- a/tests/unit/services/apis/claude-api.test.mjs
+++ b/tests/unit/services/apis/claude-api.test.mjs
@@ -119,12 +119,13 @@ test('claude-api: keeps temperature for Opus 4.6', async (t) => {
   assert.equal(body.stream, true)
 })
 
-test('claude-api: omits temperature for Opus 4.7 and 4.8', async (t) => {
+test('claude-api: omits temperature for models that reject custom sampling', async (t) => {
   t.mock.method(console, 'debug', () => {})
 
   for (const [modelName, model] of [
     ['claudeOpus47Api', 'claude-opus-4-7'],
     ['claudeOpus48Api', 'claude-opus-4-8'],
+    ['claudeSonnet5Api', 'claude-sonnet-5'],
   ]) {
     await t.test(modelName, async (t) => {
       setStorage({
@@ -158,6 +159,11 @@ test('claude-api: omits temperature for Opus 4.7 and 4.8', async (t) => {
       assert.equal(body.max_tokens, 1024)
       assert.equal(body.stream, true)
       assert.equal(Object.hasOwn(body, 'temperature'), false)
+      if (model === 'claude-sonnet-5') {
+        assert.deepEqual(body.thinking, { type: 'disabled' })
+      } else {
+        assert.equal(Object.hasOwn(body, 'thinking'), false)
+      }
     })
   }
 })


### PR DESCRIPTION
Expose Claude Sonnet 5 in the API model list and cover its request parameter behavior with tests.

Disable default thinking until the extension exposes thinking controls and response-budget handling.

References:
- https://www.anthropic.com/news/claude-sonnet-5
- https://platform.claude.com/docs/en/about-claude/models/overview
- https://platform.claude.com/docs/en/about-claude/models/whats-new-sonnet-5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Claude Sonnet 5 as an available model option.
  * Requests for this model now use the appropriate default settings for improved compatibility.
* **Bug Fixes**
  * Updated request handling so certain sampling settings are automatically adjusted for Claude Sonnet 5.
  * Disabled default “thinking” behavior for this model when sending requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->