### PR TITLE
Fix GitHub Actions: Prevent Command Injection in Firefox Workflow

### DIFF
--- a/.github/workflows/firefox-metadata.yml
+++ b/.github/workflows/firefox-metadata.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Firefox version to update, for example 2.6.1"
+        description: "Firefox version to update, for example 2.6.1 or 2.4.5.1"
         required: true
         type: string
 
@@ -27,8 +27,16 @@ jobs:
         run: npm ci
 
       - name: Update Firefox metadata
-        run: npm run release:update-firefox-metadata -- --version "${{ inputs.version }}"
+        shell: bash
+        run: |
+          if [[ ! "$FIREFOX_METADATA_VERSION" =~ ^(0|[1-9][0-9]{0,8})(\.(0|[1-9][0-9]{0,8})){2,3}$ ]]; then
+            echo "Firefox version must use x.y.z or x.y.z.w numeric format without leading zeros" >&2
+            exit 1
+          fi
+
+          npm run release:update-firefox-metadata -- --version "$FIREFOX_METADATA_VERSION"
         env:
+          FIREFOX_METADATA_VERSION: ${{ inputs.version }}
           FIREFOX_EXTENSION_ID: ${{ secrets.FIREFOX_EXTENSION_ID }}
           FIREFOX_JWT_ISSUER: ${{ secrets.FIREFOX_JWT_ISSUER }}
           FIREFOX_JWT_SECRET: ${{ secrets.FIREFOX_JWT_SECRET }}


### PR DESCRIPTION
### Motivation
- Detected that `.github/workflows/firefox-metadata.yml` directly expands `workflow_dispatch.inputs.version` into a shell `run` step, which can lead to command injection and potentially expose `FIREFOX_*` secrets.
- The goal is to eliminate the injection risk with minimal changes while preserving the existing Firefox metadata update workflow.

### Description
- Changed the workflow to pass the user input through the `FIREFOX_METADATA_VERSION` environment variable and reference it in the shell as `"$FIREFOX_METADATA_VERSION"` to prevent GitHub Actions expressions from being expanded before shell parsing.
- Added AMO-compatible numeric version validation for `x.y.z` and `x.y.z.w`, allowing up to nine digits per component while rejecting leading zeros. The step aborts before running `npm run release:update-firefox-metadata` if the input does not match.
- Explicitly selected Bash for the step that uses `[[ ... =~ ... ]]` validation.
- Modified file: `.github/workflows/firefox-metadata.yml`.

### Testing
- Ran `npm test`; all automated unit tests passed with no failures.
- Ran `npm run lint`; static analysis passed with no lint errors.
- Ran `npm run build` and verified that the expected artifacts exist in `build/chromium/`, and that `git diff --check` reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a426947c45083278b96127f3002250f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Firefox metadata updates by validating the provided Firefox version format before running the update (supports both `x.y.z` and `x.y.z.w`).
  * The workflow now fails fast when the version is malformed, reducing the risk of incorrect release metadata.
  * Added an example to the manual version input to clarify the accepted four-part version format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
