### PR TITLE
Update package-lock.json using `npm audit fix` as security update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14409,9 +14409,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
Dependency lockfile change: undici from 7.25.0 to 7.28.0

This keeps the update lockfile-only and avoids `npm audit fix --force`, which may apply breaking changes to dependencies.