### PR TITLE
Update default enabled model presets

### DIFF
--- a/src/config/index.mjs
+++ b/src/config/index.mjs
@@ -700,15 +700,19 @@ export const defaultConfig = {
   // It allows the content of activeApiModes to change with version updates when the user has not customized ApiModes.
   // If it were directly written into customApiModes, the value would become fixed, even if the user has not made any customizations.
   activeApiModes: [
-    'chatgptFree35',
     'claude2WebFree',
     'moonshotWebFree',
     'ollamaModel',
     'customModel',
     'azureOpenAi',
-    'openRouter_openai_gpt_5_5',
-    'openRouter_anthropic_claude_sonnet4_6',
-    'openRouter_google_gemini_3_5_flash',
+    'chatgptApi5_6Sol',
+    'chatgptApi5_6Terra',
+    'chatgptApi5_6Luna',
+    'claudeOpus48Api',
+    'claudeSonnet5Api',
+    'claudeHaiku45Api',
+    'openRouter_auto',
+    'openRouter_free',
   ],
   customApiModes: [
     {


### PR DESCRIPTION
Promote newer Anthropic and OpenAI API models, along with two OpenRouter auto routers, to the default-enabled list.

Remove chatgptFree35 (ChatGPT Web) from the default-enabled list, as persistent login and unusual activity failures make its complex, reverse-engineered integration too costly to maintain with current resources (refs #469, #513, #630, #713, #770, and #794).

With OpenRouter auto routers now enabled by default, drop OpenRouter defaults tied to specific models: GPT-5.5, Claude Sonnet 4.6, and Gemini 3.5 Flash. This reduces per-model maintenance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the default available AI modes with newer ChatGPT, Claude, and OpenRouter options.
  * Added automatic and free OpenRouter selections to the default configuration.

* **Improvements**
  * Removed outdated model options from the default selection list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->