### PR TITLE
feat: add Google Gemini as OpenAI-compatible API provider

### DIFF
--- a/src/background/index.mjs
+++ b/src/background/index.mjs
@@ -30,6 +30,7 @@ import {
   isUsingOpenRouterApiModel,
   isUsingAimlApiModel,
   isUsingDeepSeekApiModel,
+  isUsingGoogleApiModel,
 } from '../config/index.mjs'
 import '../_locales/i18n'
 import { openUrl } from '../utils/open-url'
@@ -345,6 +346,7 @@ function isUsingOpenAICompatibleApiSession(session) {
     isUsingOllamaApiModel(session) ||
     isUsingOpenRouterApiModel(session) ||
     isUsingAimlApiModel(session) ||
+    isUsingGoogleApiModel(session) ||
     isUsingGptCompletionApiModel(session)
   )
 }

--- a/src/config/index.mjs
+++ b/src/config/index.mjs
@@ -179,6 +179,14 @@ export const aimlApiModelKeys = [
   'aiml_deepseek_v4_pro',
   'aiml_deepseek_v4_flash',
 ]
+export const googleApiModelKeys = [
+  'googleGemini3_1Pro',
+  'googleGemini3_5Flash',
+  'googleGemini3Flash',
+  'googleGemini2_5Pro',
+  'googleGemini2_5Flash',
+  'googleGemini2_5FlashLite',
+]
 
 export const AlwaysCustomGroups = [
   'ollamaApiModelKeys',
@@ -252,6 +260,10 @@ export const ModelGroups = {
   aimlModelKeys: {
     value: aimlApiModelKeys,
     desc: 'AI/ML (API)',
+  },
+  googleApiModelKeys: {
+    value: googleApiModelKeys,
+    desc: 'Google (API)',
   },
   customApiModelKeys: {
     value: customApiModelKeys,
@@ -605,6 +617,30 @@ export const Models = {
     value: 'deepseek/deepseek-v4-flash',
     desc: 'AIML (DeepSeek V4 Flash)',
   },
+  googleGemini3_1Pro: {
+    value: 'gemini-3.1-pro-preview',
+    desc: 'Google (Gemini 3.1 Pro Preview)',
+  },
+  googleGemini3_5Flash: {
+    value: 'gemini-3.5-flash',
+    desc: 'Google (Gemini 3.5 Flash)',
+  },
+  googleGemini3Flash: {
+    value: 'gemini-3-flash-preview',
+    desc: 'Google (Gemini 3 Flash Preview)',
+  },
+  googleGemini2_5Pro: {
+    value: 'gemini-2.5-pro',
+    desc: 'Google (Gemini 2.5 Pro)',
+  },
+  googleGemini2_5Flash: {
+    value: 'gemini-2.5-flash',
+    desc: 'Google (Gemini 2.5 Flash)',
+  },
+  googleGemini2_5FlashLite: {
+    value: 'gemini-2.5-flash-lite',
+    desc: 'Google (Gemini 2.5 Flash-Lite)',
+  },
 }
 
 for (const modelName in Models) {
@@ -673,6 +709,7 @@ export const defaultConfig = {
 
   openRouterApiKey: '',
   aimlApiKey: '',
+  googleApiKey: '',
 
   // advanced
 
@@ -711,6 +748,8 @@ export const defaultConfig = {
     'claudeOpus48Api',
     'claudeSonnet5Api',
     'claudeHaiku45Api',
+    'googleGemini3_1Pro',
+    'googleGemini3_5Flash',
     'openRouter_auto',
     'openRouter_free',
   ],
@@ -866,6 +905,10 @@ export function isUsingOpenRouterApiModel(configOrSession) {
 
 export function isUsingAimlApiModel(configOrSession) {
   return isInApiModeGroup(aimlApiModelKeys, configOrSession)
+}
+
+export function isUsingGoogleApiModel(configOrSession) {
+  return isInApiModeGroup(googleApiModelKeys, configOrSession)
 }
 
 export function isUsingChatGLMApiModel(configOrSession) {

--- a/src/config/openai-provider-mappings.mjs
+++ b/src/config/openai-provider-mappings.mjs
@@ -6,6 +6,7 @@ export const LEGACY_API_KEY_FIELD_BY_PROVIDER_ID = {
   aiml: 'aimlApiKey',
   chatglm: 'chatglmApiKey',
   ollama: 'ollamaApiKey',
+  google: 'googleApiKey',
   'legacy-custom-default': 'customApiKey',
 }
 
@@ -26,5 +27,6 @@ export const OPENAI_COMPATIBLE_GROUP_TO_PROVIDER_ID = {
   aimlApiModelKeys: 'aiml',
   chatglmApiModelKeys: 'chatglm',
   ollamaApiModelKeys: 'ollama',
+  googleApiModelKeys: 'google',
   customApiModelKeys: 'legacy-custom-default',
 }

--- a/src/services/apis/provider-registry.mjs
+++ b/src/services/apis/provider-registry.mjs
@@ -71,6 +71,14 @@ const BUILTIN_PROVIDER_TEMPLATE = [
     enabled: true,
   },
   {
+    id: 'google',
+    name: 'Google',
+    baseUrl: 'https://generativelanguage.googleapis.com/v1beta/openai',
+    chatCompletionsPath: '/chat/completions',
+    builtin: true,
+    enabled: true,
+  },
+  {
     id: 'legacy-custom-default',
     name: 'Custom Model (Legacy)',
     chatCompletionsPath: '/chat/completions',
@@ -111,6 +119,7 @@ function resolveProviderIdFromLegacyModelName(modelName) {
     return 'ollama'
   }
   if (preset.startsWith('chatglm') || preset === 'chatglmApiModelKeys') return 'chatglm'
+  if (preset.startsWith('googleGemini') || preset === 'googleApiModelKeys') return 'google'
   if (preset === 'customApiModelKeys') return 'legacy-custom-default'
 
   return null

--- a/tests/unit/services/apis/provider-registry.test.mjs
+++ b/tests/unit/services/apis/provider-registry.test.mjs
@@ -6,6 +6,7 @@ import {
   getProviderById,
   resolveEndpointTypeForSession,
   resolveOpenAICompatibleRequest,
+  resolveProviderIdForSession,
 } from '../../../../src/services/apis/provider-registry.mjs'
 
 test('resolveEndpointTypeForSession prefers apiMode when present', () => {
@@ -38,6 +39,15 @@ test('resolveEndpointTypeForSession falls back to legacy modelName when apiMode 
   }
 
   assert.equal(resolveEndpointTypeForSession(session), 'completion')
+})
+
+test('resolveProviderIdForSession resolves legacy Google preset keys', () => {
+  assert.equal(resolveProviderIdForSession({ modelName: 'googleGemini2_5Flash' }), 'google')
+  assert.equal(resolveProviderIdForSession({ modelName: 'googleApiModelKeys-custom' }), 'google')
+})
+
+test('resolveProviderIdForSession does not treat raw Gemini model IDs as legacy presets', () => {
+  assert.equal(resolveProviderIdForSession({ modelName: 'gemini-2.5-flash' }), null)
 })
 
 test('resolveOpenAICompatibleRequest resolves custom provider from normalized session provider id', () => {


### PR DESCRIPTION
Add Google as a built-in OpenAI-compatible API provider using https://generativelanguage.googleapis.com/v1beta/openai/ endpoint.

Default models:
- Gemini 3.1 Pro (Preview)
- Gemini 3.5 Flash
- Gemini 3 Flash (Preview)
- Gemini 2.5 Pro
- Gemini 2.5 Flash
- Gemini 2.5 Flash-Lite

Uses the shared OpenAI-compatible Bearer authentication path and supports legacy resolution for configured Google preset keys.

Ref:
- https://ai.google.dev/gemini-api/docs/models
- https://ai.google.dev/gemini-api/docs/openai

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Google Gemini models via the Google API.
  * Introduced six new Gemini model options, including Pro, Flash, and Flash Lite variants.
  * Added Google API key configuration and Google provider recognition.
  * Updated routing so Google API model sessions use the existing OpenAI-compatible connection flow.
* **Tests**
  * Added unit coverage for Google model-to-provider resolution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->