### PR TITLE
Guard async input focus after unmount

### DIFF
--- a/src/components/InputBox/index.jsx
+++ b/src/components/InputBox/index.jsx
@@ -87,7 +87,7 @@ export function InputBox({ onSubmit, enabled, postMessage, reverseResizeDir }) {
   useEffect(() => {
     if (enabled)
       getUserConfig().then((config) => {
-        if (config.focusAfterAnswer) inputRef.current.focus()
+        if (config.focusAfterAnswer) inputRef.current?.focus()
       })
   }, [enabled])
 


### PR DESCRIPTION
## Summary

Guard the deferred input focus when `InputBox` unmounts before the user configuration finishes loading.

## Context

`getUserConfig()` reads extension storage asynchronously. If the component unmounts before that read completes, the textarea ref is cleared and calling `focus()` throws. Optional chaining preserves the mounted behavior while making the unmounted path a no-op.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented a runtime error when automatically focusing the input after an answer if the input is not yet available.
  * Improved stability for users with post-answer focus enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->