### PR TITLE
Align custom provider editor action buttons

### DIFF
--- a/src/popup/sections/ApiModes.jsx
+++ b/src/popup/sections/ApiModes.jsx
@@ -645,21 +645,22 @@ export function ApiModes({ config, updateConfig }) {
             </div>
           )}
           <div style={{ display: 'flex', gap: '12px' }}>
-            <button type="button" onClick={closeProviderEditor}>
+            <button type="button" onClick={closeProviderEditor} style={{ flex: 1 }}>
               {t('Cancel')}
             </button>
-            <button type="button" onClick={onSaveProviderEditing}>
+            <button type="button" onClick={onSaveProviderEditing} style={{ flex: 1 }}>
               {t('Save')}
             </button>
             {providerEditingId && (
               <span
                 title={providerDeleteDisabledReasonKey ? t(providerDeleteDisabledReasonKey) : ''}
-                style={{ display: 'inline-block' }}
+                style={{ display: 'flex', flex: 1 }}
               >
                 <button
                   type="button"
                   onClick={onDeleteProviderEditing}
                   disabled={isDeleteProviderDisabled}
+                  style={{ flex: 1 }}
                 >
                   {t('Delete')}
                 </button>


### PR DESCRIPTION
## Summary

Make the custom provider editor action buttons use equal flex sizing,
including the wrapped delete button.

## Why

The delete button is wrapped so its disabled-state tooltip remains
available. That extra flex layer left the button narrower than Cancel
and Save even when all labels had the same length.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved alignment and sizing of provider editor action buttons.
  * Standardized action button behavior by explicitly setting button types to avoid unintended form submissions.
  * Updated the delete control layout to match the other actions while preserving existing disabled state and tooltip behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->