### PR TITLE
Fix Baidu search verification failures and hangs

### DIFF
--- a/.github/workflows/scripts/verify-search-engine-configs.mjs
+++ b/.github/workflows/scripts/verify-search-engine-configs.mjs
@@ -1,5 +1,7 @@
 import { JSDOM } from 'jsdom'
-import fetch, { Headers } from 'node-fetch'
+import nodeFetch from 'node-fetch'
+
+const REQUEST_TIMEOUT_MS = 30_000
 
 const config = {
   google: {
@@ -42,6 +44,7 @@ const config = {
     sidebarContainerQuery: ['#content_right'],
     appendContainerQuery: ['#container'],
     resultsContainerQuery: ['#content_left', '#results'],
+    requireSameOrigin: true,
   },
   kagi: {
     inputQuery: ["input[name='q']", "textarea[name='q']"],
@@ -117,11 +120,11 @@ const commonHeaders = {
   'Accept-Language': 'zh-CN,zh;q=0.9,en-US;q=0.8,en;q=0.7', // for baidu
 }
 
-const desktopHeaders = new Headers({
+const desktopHeaders = {
   'User-Agent':
     'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36 Edg/108.0.1462.76',
   ...commonHeaders,
-})
+}
 
 const mobileHeaders = {
   'User-Agent':
@@ -140,16 +143,33 @@ const mobileQueryNames = ['inputQuery', 'resultsContainerQuery']
 
 let errors = ''
 
+function fetchSearchPage(siteName, url, options) {
+  // Baidu resets node-fetch requests, while Naver rejects global fetch requests.
+  const fetcher = siteName === 'baidu' ? globalThis.fetch : nodeFetch
+  return fetcher(url, options)
+}
+
 async function verify(errorTag, urls, headers, queryNames) {
   await Promise.all(
     Object.entries(urls).map(([siteName, urlArray]) =>
       Promise.all(
         urlArray.map((url) =>
-          fetch(url, {
+          fetchSearchPage(siteName, url, {
             method: 'GET',
             headers: headers,
+            signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
           })
-            .then((response) => response.text())
+            .then((response) => {
+              const requestedOrigin = new URL(url).origin
+              const responseOrigin = new URL(response.url).origin
+              if (config[siteName].requireSameOrigin && responseOrigin !== requestedOrigin) {
+                throw new Error(`Unexpected redirect from ${requestedOrigin} to ${responseOrigin}`)
+              }
+              if (response.status !== 200) {
+                throw new Error(`HTTP ${response.status} ${response.statusText}`)
+              }
+              return response.text()
+            })
             .then((text) => {
               const dom = new JSDOM(text)
               for (const queryName of queryNames) {
@@ -173,7 +193,9 @@ async function verify(errorTag, urls, headers, queryNames) {
               }
             })
             .catch((error) => {
-              errors += errorTag + error + '\n'
+              const errorCode = error.code ?? error.cause?.code
+              const errorCodeSuffix = errorCode ? ` (${errorCode})` : ''
+              errors += `${errorTag}${siteName} ${url}: ${error}${errorCodeSuffix}\n`
             }),
         ),
       ),

--- a/.github/workflows/verify-configs.yml
+++ b/.github/workflows/verify-configs.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   verify_configs:
     runs-on: ubuntu-22.04
+    timeout-minutes: 5
 
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
## Summary

- keep the established `node-fetch` path for Bing, Yahoo, and Naver, while using Node built-in `fetch` for Baidu to avoid the reproducible connection resets and hangs
- use plain-object headers accepted by both fetch implementations without coupling built-in `fetch` to `node-fetch` header objects
- bound each live request to 30 seconds and the workflow job to 5 minutes
- require HTTP 200 responses and report the phase, site, URL, and underlying network error code
- distinguish Baidu redirects to verification pages from selector regressions without rejecting Naver mobile redirects

## Validation

- `npm run pretty`
- `npm run lint`
- `npm test` (704 passed)
- `npm run build`
- `npm run verify` (Bing, Yahoo, Baidu, and Naver desktop/mobile checks passed)
- `node --check .github/workflows/scripts/verify-search-engine-configs.mjs`
- `git diff --check origin/master..HEAD`
- GitHub PR tests, CodeRabbit, and Kilo checks passed
- Copilot reviewed the final head and generated no new comments
- all review threads are resolved

Validation skipped: manual browser smoke tests; this change only affects the CI verifier and workflow, not extension runtime behavior.

GitHub-hosted `verify-configs` execution remains unverified because Actions are disabled on the fork; queued fork runs are not treated as evidence.