### PR TITLE
Align custom provider editor action buttons

### DIFF
--- a/src/popup/sections/ApiModes.jsx
+++ b/src/popup/sections/ApiModes.jsx
@@ -644,7 +644,13 @@ export function ApiModes({ config, updateConfig }) {
               )}
             </div>
           )}
-          <div style={{ display: 'flex', gap: '12px' }}>
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: `repeat(${providerEditingId ? 3 : 2}, minmax(0, 1fr))`,
+              gap: '12px',
+            }}
+          >
             <button type="button" onClick={closeProviderEditor}>
               {t('Cancel')}
             </button>
@@ -654,7 +660,7 @@ export function ApiModes({ config, updateConfig }) {
             {providerEditingId && (
               <span
                 title={providerDeleteDisabledReasonKey ? t(providerDeleteDisabledReasonKey) : ''}
-                style={{ display: 'inline-block' }}
+                style={{ display: 'grid' }}
               >
                 <button
                   type="button"


### PR DESCRIPTION
Use equal grid tracks for the provider editor actions so the wrapped delete button matches Cancel and Save while preserving its disabled state tooltip.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the provider editor “Cancel/Save” action bar layout to use a grid-based design for more consistent alignment.
  * The action button spacing now adapts based on whether the Delete option is available.
  * Refined the Delete button container styling to match the new grid alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->