### PR TITLE
Sync translated READMEs with English documentation

### DIFF
--- a/README_IN.md
+++ b/README_IN.md
@@ -11,7 +11,8 @@ Integrasi Deep ChatGPT di browser Anda, sepenuhnya gratis.
 [![license][license-image]][license-url]
 [![release][release-image]][release-url]
 [![size](https://img.shields.io/badge/minified%20size-390%20kB-blue)][release-url]
-[![verfiy][verify-image]][verify-url]
+[![verify][verify-image]][verify-url]
+[![coverage][coverage-image]][coverage-url]
 
 [Inggris](README.md) &nbsp;&nbsp;|&nbsp;&nbsp; Indonesia &nbsp;&nbsp;|&nbsp;&nbsp; [简体中文](README_ZH.md) &nbsp;&nbsp;|&nbsp;&nbsp; [日本語](README_JA.md) &nbsp;&nbsp;|&nbsp;&nbsp; [Türkçe](README_TR.md)
 
@@ -22,9 +23,9 @@ Integrasi Deep ChatGPT di browser Anda, sepenuhnya gratis.
 [![Firefox][Firefox-image]][Firefox-url]
 [![Safari][Safari-image]][Safari-url]
 [![Android][Android-image]][Android-url]
-[![Github][Github-image]][Github-url]
+[![GitHub][Github-image]][Github-url]
 
-[Panduan](https://github.com/ChatGPTBox-dev/chatGPTBox/wiki/Guide) &nbsp;&nbsp;|&nbsp;&nbsp; [Pratinjau](#Pratinjau) &nbsp;&nbsp;|&nbsp;&nbsp; [Pengembangan & Berkontribusi][dev-url] &nbsp;&nbsp;|&nbsp;&nbsp; [Demonstrasi Video](https://www.youtube.com/watch?v=E1smDxJvTRs) &nbsp;&nbsp;|&nbsp;&nbsp; [Kredit](#Kredit)
+[Panduan](https://github.com/ChatGPTBox-dev/chatGPTBox/wiki/Guide) &nbsp;&nbsp;|&nbsp;&nbsp; [Pratinjau](#pratinjau) &nbsp;&nbsp;|&nbsp;&nbsp; [Pengembangan & Berkontribusi][dev-url] &nbsp;&nbsp;|&nbsp;&nbsp; [Demonstrasi Video](https://www.youtube.com/watch?v=E1smDxJvTRs) &nbsp;&nbsp;|&nbsp;&nbsp; [Kredit](#kredit)
 
 [dev-url]: https://github.com/ChatGPTBox-dev/chatGPTBox/wiki/Development&Contributing
 
@@ -39,6 +40,10 @@ Integrasi Deep ChatGPT di browser Anda, sepenuhnya gratis.
 [verify-image]: https://github.com/ChatGPTBox-dev/chatGPTBox/workflows/verify-configs/badge.svg
 
 [verify-url]: https://github.com/ChatGPTBox-dev/chatGPTBox/actions/workflows/verify-configs.yml
+
+[coverage-image]: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/ChatGPTBox-dev/chatGPTBox/master/badges/coverage.json
+
+[coverage-url]: https://github.com/ChatGPTBox-dev/chatGPTBox/actions/workflows/pr-tests.yml
 
 [Chrome-image]: https://img.shields.io/badge/-Chrome-brightgreen?logo=google-chrome&logoColor=white
 
@@ -69,6 +74,8 @@ Integrasi Deep ChatGPT di browser Anda, sepenuhnya gratis.
 ## Berita
 
 - Ekstensi ini **tidak** mengumpulkan data Anda. Anda dapat memverifikasinya dengan melakukan pencarian global untuk `fetch(` dan `XMLHttpRequest(` dalam kode untuk menemukan semua panggilan permintaan jaringan. Jumlah kode tidak banyak, jadi mudah untuk melakukannya.
+
+- Alat ini tidak akan mengirimkan data apa pun ke ChatGPT kecuali Anda secara eksplisit memintanya. Secara default, ekstensi harus diaktifkan secara manual. Permintaan hanya akan dikirim ke ChatGPT jika Anda secara khusus mengklik "Ask ChatGPT" atau memicu alat pilihan mengambang — dan ini hanya berlaku saat Anda menggunakan mode GPT API. (issue #407)
 
 - Anda dapat menggunakan proyek seperti https://github.com/BerriAI/litellm / https://github.com/songquanpeng/one-api untuk mengkonversi API LLM ke dalam format OpenAI dan menggunakannya bersama dengan mode `Custom Model` dari ChatGPTBox
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -11,7 +11,8 @@
 [![license][license-image]][license-url]
 [![release][release-image]][release-url]
 [![size](https://img.shields.io/badge/minified%20size-390%20kB-blue)][release-url]
-[![verfiy][verify-image]][verify-url]
+[![verify][verify-image]][verify-url]
+[![coverage][coverage-image]][coverage-url]
 
 [English](README.md) &nbsp;&nbsp;|&nbsp;&nbsp; [Indonesia](README_IN.md) &nbsp;&nbsp;|&nbsp;&nbsp; [简体中文](README_ZH.md) &nbsp;&nbsp;|&nbsp;&nbsp; 日本語 &nbsp;&nbsp;|&nbsp;&nbsp; [Türkçe](README_TR.md)
 
@@ -22,7 +23,7 @@
 [![Firefox][Firefox-image]][Firefox-url]
 [![Safari][Safari-image]][Safari-url]
 [![Android][Android-image]][Android-url]
-[![Github][Github-image]][Github-url]
+[![GitHub][Github-image]][Github-url]
 
 [ガイド](https://github.com/ChatGPTBox-dev/chatGPTBox/wiki/Guide) &nbsp;&nbsp;|&nbsp;&nbsp; [プレビュー](#プレビュー) &nbsp;&nbsp;|&nbsp;&nbsp; [開発 & コントリビュート][dev-url] &nbsp;&nbsp;|&nbsp;&nbsp; [ビデオデモ](https://www.youtube.com/watch?v=E1smDxJvTRs) &nbsp;&nbsp;|&nbsp;&nbsp; [クレジット](#クレジット)
 
@@ -39,6 +40,10 @@
 [verify-image]: https://github.com/ChatGPTBox-dev/chatGPTBox/workflows/verify-configs/badge.svg
 
 [verify-url]: https://github.com/ChatGPTBox-dev/chatGPTBox/actions/workflows/verify-configs.yml
+
+[coverage-image]: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/ChatGPTBox-dev/chatGPTBox/master/badges/coverage.json
+
+[coverage-url]: https://github.com/ChatGPTBox-dev/chatGPTBox/actions/workflows/pr-tests.yml
 
 [Chrome-image]: https://img.shields.io/badge/-Chrome-brightgreen?logo=google-chrome&logoColor=white
 
@@ -74,7 +79,7 @@
 
 - https://github.com/BerriAI/litellm / https://github.com/songquanpeng/one-api のようなプロジェクトを使用して、LLM APIをOpenAI形式に変換し、それらをChatGPTBoxの `カスタムモデル` モードと組み合わせて使用することができます
 
-- もちろんです。ChatGPTBoxの `カスタムモデル` モードを使用する際には、[Ollama](https://github.com/ChatGPTBox-dev/chatGPTBox/issues/616#issuecomment-1975186467) / https://openrouter.ai/docs#models もご利用いただけます
+- ChatGPTBoxの `カスタムモデル` モードを使用する際には、[Ollama](https://github.com/ChatGPTBox-dev/chatGPTBox/issues/616#issuecomment-1975186467) / https://openrouter.ai/docs#models もご利用いただけます
 
 ## ✨ 機能
 

--- a/README_TR.md
+++ b/README_TR.md
@@ -12,7 +12,8 @@ Tarayıcınıza derin ChatGPT entegrasyonu, tamamen ücretsiz.
 [![license][license-image]][license-url]
 [![release][release-image]][release-url]
 [![size](https://img.shields.io/badge/minified%20size-390%20kB-blue)][release-url]
-[![verfiy][verify-image]][verify-url]
+[![verify][verify-image]][verify-url]
+[![coverage][coverage-image]][coverage-url]
 
 [English](README.md) &nbsp;&nbsp;|&nbsp;&nbsp; [Indonesia](README_IN.md) &nbsp;&nbsp;|&nbsp;&nbsp; [简体中文](README_ZH.md) &nbsp;&nbsp;|&nbsp;&nbsp; [日本語](README_JA.md) &nbsp;&nbsp;|&nbsp;&nbsp; Türkçe
 
@@ -23,9 +24,9 @@ Tarayıcınıza derin ChatGPT entegrasyonu, tamamen ücretsiz.
 [![Firefox][Firefox-image]][Firefox-url]
 [![Safari][Safari-image]][Safari-url]
 [![Android][Android-image]][Android-url]
-[![Github][Github-image]][Github-url]
+[![GitHub][Github-image]][Github-url]
 
-[Rehber](https://github.com/ChatGPTBox-dev/chatGPTBox/wiki/Guide) &nbsp;&nbsp;|&nbsp;&nbsp; [Önizleme](#Preview) &nbsp;&nbsp;|&nbsp;&nbsp; [Gelişim ve Katkı Sağlama][dev-url] &nbsp;&nbsp;|&nbsp;&nbsp; [Video](https://www.youtube.com/watch?v=E1smDxJvTRs) &nbsp;&nbsp;|&nbsp;&nbsp; [Credit](#Credit)
+[Rehber](https://github.com/ChatGPTBox-dev/chatGPTBox/wiki/Guide) &nbsp;&nbsp;|&nbsp;&nbsp; [Önizleme](#önizleme) &nbsp;&nbsp;|&nbsp;&nbsp; [Gelişim ve Katkı Sağlama][dev-url] &nbsp;&nbsp;|&nbsp;&nbsp; [Video](https://www.youtube.com/watch?v=E1smDxJvTRs) &nbsp;&nbsp;|&nbsp;&nbsp; [Credits](#katkıda-bulunanlar)
 
 [dev-url]: https://github.com/ChatGPTBox-dev/chatGPTBox/wiki/Development&Contributing
 
@@ -40,6 +41,10 @@ Tarayıcınıza derin ChatGPT entegrasyonu, tamamen ücretsiz.
 [verify-image]: https://github.com/ChatGPTBox-dev/chatGPTBox/workflows/verify-configs/badge.svg
 
 [verify-url]: https://github.com/ChatGPTBox-dev/chatGPTBox/actions/workflows/verify-configs.yml
+
+[coverage-image]: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/ChatGPTBox-dev/chatGPTBox/master/badges/coverage.json
+
+[coverage-url]: https://github.com/ChatGPTBox-dev/chatGPTBox/actions/workflows/pr-tests.yml
 
 [Chrome-image]: https://img.shields.io/badge/-Chrome-brightgreen?logo=google-chrome&logoColor=white
 
@@ -93,7 +98,7 @@ Tarayıcınıza derin ChatGPT entegrasyonu, tamamen ücretsiz.
 - 🌍 Dil tercih desteği.
 - 📝 Özel API adres desteği.
 - ⚙️ Tüm site adaptasyonları ve seçim araçları(sohbet balonu) özgürce açıp kapatılabilir, ihtiyacınız olmayan modülleri kapatın.
-- 💡 Seçim araçları ve site adaptasyonunun geliştirilmesi kolay ve geniştir, [Development&Contributing][dev-url] bölümüne bakınız.
+- 💡 Seçim araçları ve site adaptasyonunun geliştirilmesi kolay ve geniştir, [Development & Contributing][dev-url] bölümüne bakınız.
 - 😉 Yanıt kalitesini artırmak için sohbet edin.
 
 ## Önizleme

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -11,7 +11,8 @@
 [![license][license-image]][license-url]
 [![release][release-image]][release-url]
 [![size](https://img.shields.io/badge/minified%20size-390%20kB-blue)][release-url]
-[![verfiy][verify-image]][verify-url]
+[![verify][verify-image]][verify-url]
+[![coverage][coverage-image]][coverage-url]
 
 [English](README.md) &nbsp;&nbsp;|&nbsp;&nbsp; [Indonesia](README_IN.md) &nbsp;&nbsp;|&nbsp;&nbsp; 简体中文 &nbsp;&nbsp;|&nbsp;&nbsp; [日本語](README_JA.md) &nbsp;&nbsp;|&nbsp;&nbsp; [Türkçe](README_TR.md)
 
@@ -22,9 +23,9 @@
 [![Firefox][Firefox-image]][Firefox-url]
 [![Safari][Safari-image]][Safari-url]
 [![Android][Android-image]][Android-url]
-[![Github][Github-image]][Github-url]
+[![GitHub][Github-image]][Github-url]
 
-[使用指南](https://github.com/ChatGPTBox-dev/chatGPTBox/wiki/Guide) &nbsp;&nbsp;|&nbsp;&nbsp; [效果预览](#Preview) &nbsp;&nbsp;|&nbsp;&nbsp; [开发&贡献][dev-url] &nbsp;&nbsp;|&nbsp;&nbsp; [视频演示](https://www.bilibili.com/video/BV1524y1x7io) &nbsp;&nbsp;|&nbsp;&nbsp; [鸣谢](#Credit)
+[使用指南](https://github.com/ChatGPTBox-dev/chatGPTBox/wiki/Guide) &nbsp;&nbsp;|&nbsp;&nbsp; [效果预览](#preview) &nbsp;&nbsp;|&nbsp;&nbsp; [开发&贡献][dev-url] &nbsp;&nbsp;|&nbsp;&nbsp; [视频演示](https://www.bilibili.com/video/BV1524y1x7io) &nbsp;&nbsp;|&nbsp;&nbsp; [鸣谢](#credits)
 
 [dev-url]: https://github.com/ChatGPTBox-dev/chatGPTBox/wiki/Development&Contributing
 
@@ -39,6 +40,10 @@
 [verify-image]: https://github.com/ChatGPTBox-dev/chatGPTBox/workflows/verify-configs/badge.svg
 
 [verify-url]: https://github.com/ChatGPTBox-dev/chatGPTBox/actions/workflows/verify-configs.yml
+
+[coverage-image]: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/ChatGPTBox-dev/chatGPTBox/master/badges/coverage.json
+
+[coverage-url]: https://github.com/ChatGPTBox-dev/chatGPTBox/actions/workflows/pr-tests.yml
 
 [Chrome-image]: https://img.shields.io/badge/-Chrome-brightgreen?logo=google-chrome&logoColor=white
 
@@ -70,6 +75,8 @@
 
 - 这个扩展程序不收集你的数据, 你可以通过对代码全局搜索 `fetch(` 和 `XMLHttpRequest(` 找到所有的网络请求调用. 代码量不多, 所以很容易验证.
 
+- 此工具不会向 ChatGPT 传输任何数据，除非你明确要求。默认情况下，扩展程序需要手动激活。只有当你专门点击 “Ask ChatGPT” 或触发选择浮动工具时才会发送请求——这仅在使用 GPT API 模式时适用。（issue #407）
+
 - 你可以使用像 https://github.com/BerriAI/litellm / https://github.com/songquanpeng/one-api 这样的项目，将各种 大语言模型 API 转换为OpenAI格式，并与ChatGPTBox的`自定义模型`模式结合使用
 
 - 对于国内用户, 有GPT, Midjourney, Netflix等账号需求的, 可以考虑此站点购买合租, 此链接购买的订单也会给我带来一定收益, 作为对本项目的支持: https://nf.video/yinhe/web?sharedId=84599
@@ -92,7 +99,7 @@
 - 🖨️ 随意保存你的完整对话记录, 或进行局部复制
 - 🎨 强大的渲染支持, 不论是代码高亮, 还是复杂数学公式
 - 🌍 多语言偏好支持
-- 📝 [自定义API地址](https://github.com/Ice-Hazymoon/openai-scf-proxy)支持
+- 📝 自定义API地址支持
 - ⚙️ 所有站点适配与工具均可自由开关, 随时停用你不需要的模块
 - 💡 工具与站点适配开发易于扩展, 对于开发人员易于自定义, 请查看[开发&贡献][dev-url]部分
 - 😉 此外, 如果回答有任何不足, 直接聊天解决!
@@ -131,7 +138,7 @@
 
 </div>
 
-## Credit
+## Credits
 
 该项目基于我的另一个项目 [josStorer/chatGPT-search-engine-extension](https://github.com/josStorer/chatGPT-search-engine-extension)
 


### PR DESCRIPTION
GitHub Copilot Pull Request Summary:

> This pull request updates the Indonesian (`README_IN.md`), Japanese (`README_JA.md`), Turkish (`README_TR.md`), and Simplified Chinese (`README_ZH.md`) README files to add a test coverage badge, clarify privacy details, and make minor improvements to feature descriptions and explanations. These changes improve transparency, consistency, and clarity across the documentation.
> 
> **Documentation improvements:**
> 
> * Added a test coverage badge to the top of all localized README files, including the necessary image and link references. [[1]](diffhunk://#diff-28510f7acb382cb4cc8eb4d31fd41e1f3f7908892ab284214fcc0b6e228c98c2R15) [[2]](diffhunk://#diff-f271b36948d7c29cd89eec7d160e57e411e28bd496449f272c70df1ff4e5f32cR15) [[3]](diffhunk://#diff-657e7dc5a62bae53aac79a28e274c8407a08b7ac6e391a47bd86e473c3feaf59R16) [[4]](diffhunk://#diff-e8764f49c916f94863b7aad80d30a29f7761a297d0b24be2c244cf90ce23d85aR15) [[5]](diffhunk://#diff-28510f7acb382cb4cc8eb4d31fd41e1f3f7908892ab284214fcc0b6e228c98c2R44-R47) [[6]](diffhunk://#diff-f271b36948d7c29cd89eec7d160e57e411e28bd496449f272c70df1ff4e5f32cR44-R47) [[7]](diffhunk://#diff-657e7dc5a62bae53aac79a28e274c8407a08b7ac6e391a47bd86e473c3feaf59R45-R48) [[8]](diffhunk://#diff-e8764f49c916f94863b7aad80d30a29f7761a297d0b24be2c244cf90ce23d85aR44-R47)
> 
> **Privacy and usage clarifications:**
> 
> * Clarified in `README_IN.md` and `README_ZH.md` that the extension does not send any data to ChatGPT unless explicitly requested by the user, and that the extension is disabled by default and only sends requests when the user interacts with it in GPT API mode. [[1]](diffhunk://#diff-28510f7acb382cb4cc8eb4d31fd41e1f3f7908892ab284214fcc0b6e228c98c2R78-R79) [[2]](diffhunk://#diff-e8764f49c916f94863b7aad80d30a29f7761a297d0b24be2c244cf90ce23d85aR78-R79)
> 
> **Feature and explanation improvements:**
> 
> * Simplified and clarified feature descriptions, such as removing unnecessary links or explanations about custom API support and usage of Ollama/OpenRouter in `README_JA.md` and `README_ZH.md`. [[1]](diffhunk://#diff-f271b36948d7c29cd89eec7d160e57e411e28bd496449f272c70df1ff4e5f32cL77-R82) [[2]](diffhunk://#diff-e8764f49c916f94863b7aad80d30a29f7761a297d0b24be2c244cf90ce23d85aL95-R102)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a coverage status badge to the top badge row and included the related badge image/link references across multiple localized READMEs.
  - Updated privacy/news wording to clarify that data is not sent to ChatGPT by default; requests are only sent after explicit user action, and only in GPT API mode.
  - Refreshed localized header badges/links and made small consistency edits to text and anchors (including adding a GitHub install link).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->