### PR TITLE
Add Anthropic Claude Opus 5 API support

### DIFF
--- a/src/_locales/en/main.json
+++ b/src/_locales/en/main.json
@@ -195,6 +195,7 @@
   "Anthropic (Claude Opus 4.5)": "Anthropic (Claude Opus 4.5)",
   "Anthropic (Claude Opus 4.6)": "Anthropic (Claude Opus 4.6)",
   "Anthropic (Claude Opus 4.8)": "Anthropic (Claude Opus 4.8)",
+  "Anthropic (Claude Opus 5)": "Anthropic (Claude Opus 5)",
   "Anthropic (Claude Sonnet 4)": "Anthropic (Claude Sonnet 4)",
   "Anthropic (Claude Sonnet 4.5)": "Anthropic (Claude Sonnet 4.5)",
   "Anthropic (Claude Haiku 4.5)": "Anthropic (Claude Haiku 4.5)",

--- a/src/config/index.mjs
+++ b/src/config/index.mjs
@@ -91,6 +91,7 @@ export const claudeApiModelKeys = [
   'claudeOpus46Api',
   'claudeOpus47Api',
   'claudeOpus48Api',
+  'claudeOpus5Api',
   'claudeSonnet45Api',
   'claudeSonnet46Api',
   'claudeSonnet5Api',
@@ -363,6 +364,10 @@ export const Models = {
   claudeOpus48Api: {
     value: 'claude-opus-4-8',
     desc: 'Anthropic (Claude Opus 4.8)',
+  },
+  claudeOpus5Api: {
+    value: 'claude-opus-5',
+    desc: 'Anthropic (Claude Opus 5)',
   },
   claudeSonnet45Api: {
     value: 'claude-sonnet-4-5-20250929',
@@ -750,7 +755,7 @@ export const defaultApiModeIds = [
   'chatgptApi5_6Terra',
   'chatgptApi5_6Luna',
   'xaiGrok4_5',
-  'claudeOpus48Api',
+  'claudeOpus5Api',
   'claudeSonnet5Api',
   'claudeHaiku45Api',
   'googleGemini3_1Pro',

--- a/src/services/apis/claude-api.mjs
+++ b/src/services/apis/claude-api.mjs
@@ -6,7 +6,12 @@ import { getConversationPairs } from '../../utils/get-conversation-pairs.mjs'
 import { getModelValue } from '../../utils/model-name-convert.mjs'
 
 function shouldOmitTemperature(model) {
-  return model === 'claude-opus-4-7' || model === 'claude-opus-4-8' || model === 'claude-sonnet-5'
+  return (
+    model === 'claude-opus-4-7' ||
+    model === 'claude-opus-4-8' ||
+    model === 'claude-sonnet-5' ||
+    model === 'claude-opus-5'
+  )
 }
 
 function shouldDisableDefaultThinking(model) {

--- a/tests/unit/services/apis/claude-api.test.mjs
+++ b/tests/unit/services/apis/claude-api.test.mjs
@@ -125,6 +125,7 @@ test('claude-api: omits temperature for models that reject custom sampling', asy
   for (const [modelName, model] of [
     ['claudeOpus47Api', 'claude-opus-4-7'],
     ['claudeOpus48Api', 'claude-opus-4-8'],
+    ['claudeOpus5Api', 'claude-opus-5'],
     ['claudeSonnet5Api', 'claude-sonnet-5'],
   ]) {
     await t.test(modelName, async (t) => {


### PR DESCRIPTION
Expose Claude Opus 5 through the Anthropic API model list using the official `claude-opus-5` model identifier.

## Changes

- Register Claude Opus 5 and add its English display label.
- Make Claude Opus 5 the default Opus-tier API option while keeping Claude Opus 4.8 selectable.
- Preserve Claude Opus 5's default adaptive thinking behavior.
- Omit the unsupported custom `temperature` parameter from Claude Opus 5 requests.
- Extend the parameterized Claude API request-shaping test for Opus 5.

## Validation

- `npm run lint`
- `npm test` (932 tests passed)
- `npm run build`

## References

- https://www.anthropic.com/claude-opus-5-system-card
- https://www.anthropic.com/news/claude-opus-5
- https://platform.claude.com/docs/en/about-claude/models/overview
- https://platform.claude.com/docs/en/about-claude/models/whats-new-opus-5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the Anthropic Claude Opus 5 model.
  * Claude Opus 5 is now available as a default active model with localized labeling.

* **Bug Fixes**
  * Requests to Claude Opus 5 no longer include unsupported custom temperature settings.

* **Tests**
  * Added coverage verifying correct Claude Opus 5 request behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->