### PR TITLE
Reject HTTP error pages before limitedFetch returns truncated data

### DIFF
--- a/src/utils/limited-fetch.mjs
+++ b/src/utils/limited-fetch.mjs
@@ -4,12 +4,22 @@ export async function limitedFetch(url, maxBytes) {
   return new Promise((resolve, reject) => {
     try {
       const xhr = new XMLHttpRequest()
+      const rejectHttpError = () => reject(new Error(String(xhr.status)))
+      const isSuccessfulStatus = () => xhr.status >= 200 && xhr.status < 300
       xhr.onprogress = (ev) => {
         if (ev.loaded < maxBytes) return
-        resolve(ev.target.responseText.substring(0, maxBytes))
+        if (isSuccessfulStatus()) {
+          resolve(ev.target.responseText.substring(0, maxBytes))
+        } else {
+          rejectHttpError()
+        }
         xhr.abort()
       }
       xhr.onload = (ev) => {
+        if (!isSuccessfulStatus()) {
+          rejectHttpError()
+          return
+        }
         resolve(ev.target.responseText.substring(0, maxBytes))
       }
       xhr.onerror = (ev) => {

--- a/tests/unit/utils/limited-fetch.test.mjs
+++ b/tests/unit/utils/limited-fetch.test.mjs
@@ -15,12 +15,13 @@ const restoreXMLHttpRequest = () => {
   }
 }
 
-const installFakeXMLHttpRequest = ({ openError, sendError } = {}) => {
+const installFakeXMLHttpRequest = ({ openError, sendError, status = 200 } = {}) => {
   const requests = []
 
   class FakeXMLHttpRequest {
     constructor() {
       this.aborted = false
+      this.status = status
       requests.push(this)
     }
 
@@ -111,6 +112,65 @@ test('limitedFetch truncates a completed response without aborting it', async ()
 
   assert.equal(await responsePromise, 'abcd')
   assert.equal(request.aborted, false)
+})
+
+test('limitedFetch rejects HTTP errors that complete with response data', async () => {
+  const requests = installFakeXMLHttpRequest({ status: 503 })
+  const responsePromise = limitedFetch('https://example.com/data', 20)
+  const [request] = requests
+
+  request.onload({
+    target: { responseText: 'service unavailable' },
+  })
+
+  await assert.rejects(responsePromise, {
+    name: 'Error',
+    message: '503',
+  })
+  assert.equal(request.aborted, false)
+})
+
+test('limitedFetch rejects and aborts an oversized HTTP error response', async () => {
+  const requests = installFakeXMLHttpRequest({ status: 429 })
+  const responsePromise = limitedFetch('https://example.com/data', 5)
+  const [request] = requests
+
+  request.onprogress({
+    loaded: 5,
+    target: { responseText: 'rate limited' },
+  })
+
+  await assert.rejects(responsePromise, {
+    name: 'Error',
+    message: '429',
+  })
+  assert.equal(request.aborted, true)
+})
+
+test('limitedFetch accepts successful partial-content responses', async () => {
+  const requests = installFakeXMLHttpRequest({ status: 206 })
+  const responsePromise = limitedFetch('https://example.com/data', 4)
+  const [request] = requests
+
+  request.onload({
+    target: { responseText: 'partial content' },
+  })
+
+  assert.equal(await responsePromise, 'part')
+})
+
+test('limitedFetch truncates and aborts partial content at the byte limit', async () => {
+  const requests = installFakeXMLHttpRequest({ status: 206 })
+  const responsePromise = limitedFetch('https://example.com/data', 4)
+  const [request] = requests
+
+  request.onprogress({
+    loaded: 4,
+    target: { responseText: 'partial content' },
+  })
+
+  assert.equal(await responsePromise, 'part')
+  assert.equal(request.aborted, true)
 })
 
 test('limitedFetch rejects with the XHR status when the request fails', async () => {


### PR DESCRIPTION
## Problem

`XMLHttpRequest` reports completed HTTP error responses through `load`, not `error`. Because `limitedFetch` resolved every completed response, a 4xx or 5xx error page could be truncated and passed to the GitHub or GitLab patch-analysis path as if it were valid content.

The same problem existed in the early size-limit path: an oversized error response could resolve before the request was aborted.

## Changes

- Require a successful 2xx status before resolving from either completion path.
- Reject oversized HTTP error responses before aborting their downloads.
- Preserve successful partial-content responses such as HTTP 206 in both completion paths.
- Add regression coverage for normal and oversized error responses and partial-content truncation.

## Validation

- Focused `limitedFetch` regression tests passed, including HTTP 206 through both normal completion and the size-limit path.
- `node --check` passed for the changed JavaScript modules.