### PR TITLE
Preserve every config change during rapid storage updates

### DIFF
--- a/src/hooks/config-storage-listener.mjs
+++ b/src/hooks/config-storage-listener.mjs
@@ -1,0 +1,12 @@
+export function createConfigStorageListener(setConfig, ignoreSession = true) {
+  return (changes) => {
+    const changedKeys = Object.keys(changes)
+    if (ignoreSession && changedKeys.length === 1 && changedKeys[0] === 'sessions') return
+
+    const configUpdate = Object.create(null)
+    for (const key of changedKeys) {
+      configUpdate[key] = changes[key].newValue
+    }
+    setConfig((currentConfig) => ({ ...currentConfig, ...configUpdate }))
+  }
+}

--- a/src/hooks/config-storage-listener.mjs
+++ b/src/hooks/config-storage-listener.mjs
@@ -1,0 +1,11 @@
+export function createConfigStorageListener(setConfig, ignoreSession = true) {
+  return (changes) => {
+    if (ignoreSession && Object.keys(changes).length === 1 && 'sessions' in changes) return
+
+    const configUpdate = {}
+    for (const key of Object.keys(changes)) {
+      configUpdate[key] = changes[key].newValue
+    }
+    setConfig((currentConfig) => ({ ...currentConfig, ...configUpdate }))
+  }
+}

--- a/src/hooks/use-config.mjs
+++ b/src/hooks/use-config.mjs
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { defaultConfig, getUserConfig } from '../config/index.mjs'
 import Browser from 'webextension-polyfill'
+import { createConfigStorageListener } from './config-storage-listener.mjs'
 
 export function useConfig(initFn, ignoreSession = true) {
   const [config, setConfig] = useState(defaultConfig)
@@ -11,20 +12,11 @@ export function useConfig(initFn, ignoreSession = true) {
     })
   }, [])
   useEffect(() => {
-    const listener = (changes) => {
-      if (ignoreSession) if (Object.keys(changes).length === 1 && 'sessions' in changes) return
-
-      const changedItems = Object.keys(changes)
-      let newConfig = {}
-      for (const key of changedItems) {
-        newConfig[key] = changes[key].newValue
-      }
-      setConfig({ ...config, ...newConfig })
-    }
+    const listener = createConfigStorageListener(setConfig, ignoreSession)
     Browser.storage.local.onChanged.addListener(listener)
     return () => {
       Browser.storage.local.onChanged.removeListener(listener)
     }
-  }, [config])
+  }, [ignoreSession])
   return config
 }

--- a/tests/unit/hooks/config-storage-listener.test.mjs
+++ b/tests/unit/hooks/config-storage-listener.test.mjs
@@ -1,0 +1,92 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { createConfigStorageListener } from '../../../src/hooks/config-storage-listener.mjs'
+
+const collectUpdates = () => {
+  const updates = []
+  return {
+    updates,
+    setConfig(update) {
+      updates.push(update)
+    },
+  }
+}
+
+test('storage changes merge against the latest queued config state', () => {
+  const { updates, setConfig } = collectUpdates()
+  const listener = createConfigStorageListener(setConfig)
+
+  listener({ themeMode: { oldValue: 'light', newValue: 'dark' } })
+  listener({ preferredLanguage: { oldValue: 'en', newValue: 'zh_TW' } })
+
+  assert.equal(updates.length, 2)
+  assert.equal(typeof updates[0], 'function')
+  assert.equal(typeof updates[1], 'function')
+
+  const config = updates.reduce(
+    (currentConfig, update) => update(currentConfig),
+    { themeMode: 'light', preferredLanguage: 'en', modelName: 'chatgptFree35' },
+  )
+
+  assert.deepEqual(config, {
+    themeMode: 'dark',
+    preferredLanguage: 'zh_TW',
+    modelName: 'chatgptFree35',
+  })
+})
+
+test('session-only changes remain ignored by default', () => {
+  const { updates, setConfig } = collectUpdates()
+  const listener = createConfigStorageListener(setConfig)
+
+  listener({ sessions: { oldValue: [], newValue: [{ id: 'session-1' }] } })
+
+  assert.deepEqual(updates, [])
+})
+
+test('mixed changes still update config when sessions are ignored', () => {
+  const { updates, setConfig } = collectUpdates()
+  const listener = createConfigStorageListener(setConfig)
+
+  listener({
+    sessions: { oldValue: [], newValue: [{ id: 'session-1' }] },
+    themeMode: { oldValue: 'light', newValue: 'dark' },
+  })
+
+  assert.equal(updates.length, 1)
+  assert.deepEqual(updates[0]({ themeMode: 'light' }), {
+    sessions: [{ id: 'session-1' }],
+    themeMode: 'dark',
+  })
+})
+
+test('session-only changes update config when filtering is disabled', () => {
+  const { updates, setConfig } = collectUpdates()
+  const listener = createConfigStorageListener(setConfig, false)
+  const sessions = [{ id: 'session-1' }]
+
+  listener({ sessions: { oldValue: [], newValue: sessions } })
+
+  assert.equal(updates.length, 1)
+  assert.deepEqual(updates[0]({ themeMode: 'light' }), {
+    themeMode: 'light',
+    sessions,
+  })
+})
+
+test('special storage keys remain own config properties without prototype mutation', () => {
+  const { updates, setConfig } = collectUpdates()
+  const listener = createConfigStorageListener(setConfig)
+  const changes = Object.create(null)
+  const specialValue = { source: 'storage' }
+  changes.__proto__ = { oldValue: undefined, newValue: specialValue }
+
+  listener(changes)
+
+  assert.equal(updates.length, 1)
+  const config = updates[0]({ themeMode: 'light' })
+  assert.equal(Object.getPrototypeOf(config), Object.prototype)
+  assert.equal(Object.hasOwn(config, '__proto__'), true)
+  assert.equal(config.__proto__, specialValue)
+  assert.equal({}.source, undefined)
+})

--- a/tests/unit/hooks/config-storage-listener.test.mjs
+++ b/tests/unit/hooks/config-storage-listener.test.mjs
@@ -1,0 +1,75 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { createConfigStorageListener } from '../../../src/hooks/config-storage-listener.mjs'
+
+const collectUpdates = () => {
+  const updates = []
+  return {
+    updates,
+    setConfig(update) {
+      updates.push(update)
+    },
+  }
+}
+
+test('storage changes merge against the latest queued config state', () => {
+  const { updates, setConfig } = collectUpdates()
+  const listener = createConfigStorageListener(setConfig)
+
+  listener({ themeMode: { oldValue: 'light', newValue: 'dark' } })
+  listener({ preferredLanguage: { oldValue: 'en', newValue: 'zh_TW' } })
+
+  assert.equal(updates.length, 2)
+  assert.equal(typeof updates[0], 'function')
+  assert.equal(typeof updates[1], 'function')
+
+  const config = updates.reduce(
+    (currentConfig, update) => update(currentConfig),
+    { themeMode: 'light', preferredLanguage: 'en', modelName: 'chatgptFree35' },
+  )
+
+  assert.deepEqual(config, {
+    themeMode: 'dark',
+    preferredLanguage: 'zh_TW',
+    modelName: 'chatgptFree35',
+  })
+})
+
+test('session-only changes remain ignored by default', () => {
+  const { updates, setConfig } = collectUpdates()
+  const listener = createConfigStorageListener(setConfig)
+
+  listener({ sessions: { oldValue: [], newValue: [{ id: 'session-1' }] } })
+
+  assert.deepEqual(updates, [])
+})
+
+test('mixed changes still update config when sessions are ignored', () => {
+  const { updates, setConfig } = collectUpdates()
+  const listener = createConfigStorageListener(setConfig)
+
+  listener({
+    sessions: { oldValue: [], newValue: [{ id: 'session-1' }] },
+    themeMode: { oldValue: 'light', newValue: 'dark' },
+  })
+
+  assert.equal(updates.length, 1)
+  assert.deepEqual(updates[0]({ themeMode: 'light' }), {
+    sessions: [{ id: 'session-1' }],
+    themeMode: 'dark',
+  })
+})
+
+test('session-only changes update config when filtering is disabled', () => {
+  const { updates, setConfig } = collectUpdates()
+  const listener = createConfigStorageListener(setConfig, false)
+  const sessions = [{ id: 'session-1' }]
+
+  listener({ sessions: { oldValue: [], newValue: sessions } })
+
+  assert.equal(updates.length, 1)
+  assert.deepEqual(updates[0]({ themeMode: 'light' }), {
+    themeMode: 'light',
+    sessions,
+  })
+})


### PR DESCRIPTION
## Problem

`useConfig` merged each storage event into the `config` object captured by the current render. Multiple storage callbacks can run before Preact refreshes that closure, so a later object update could overwrite an earlier queued change.

The effect also removed and re-added the storage listener after every config update because `config` was in its dependency list.

## Changes

- Convert storage patches into functional state updates that always receive the latest queued config.
- Keep the storage listener stable unless the session-filter option changes.
- Capture changed storage keys once and reuse them for filtering and patch construction.
- Stage patches in a null-prototype object so special storage keys remain ordinary data.
- Preserve and test both session-filter modes, including the Independent Panel path that keeps session-only updates.

## Validation

- `node --test tests/unit/hooks/config-storage-listener.test.mjs` — 5 tests passed.
- `node --check` passed for the changed JavaScript modules.