### PR TITLE
Keep IME candidate confirmation from sending or stopping chat

### DIFF
--- a/src/components/InputBox/index.jsx
+++ b/src/components/InputBox/index.jsx
@@ -11,6 +11,7 @@ import {
   MIN_CONVERSATION_HEIGHT,
   MIN_INPUT_HEIGHT,
 } from './resize.mjs'
+import { shouldHandleInputAction } from './input-action.mjs'
 
 export function InputBox({ onSubmit, enabled, postMessage, reverseResizeDir }) {
   const { t } = useTranslation()
@@ -93,7 +94,7 @@ export function InputBox({ onSubmit, enabled, postMessage, reverseResizeDir }) {
 
   const handleKeyDownOrClick = (e) => {
     e.stopPropagation()
-    if (e.type === 'click' || (e.keyCode === 13 && e.shiftKey === false)) {
+    if (shouldHandleInputAction(e)) {
       e.preventDefault()
       if (enabled) {
         if (!value) return

--- a/src/components/InputBox/input-action.mjs
+++ b/src/components/InputBox/input-action.mjs
@@ -1,0 +1,10 @@
+export function shouldHandleInputAction(event) {
+  if (event.type === 'click') return true
+  if (event.type !== 'keydown') return false
+
+  const isComposing = event.isComposing || event.nativeEvent?.isComposing
+  if (isComposing || event.keyCode === 229) return false
+
+  const isEnter = event.key === 'Enter' || event.keyCode === 13
+  return isEnter && !event.shiftKey
+}

--- a/tests/unit/components/input-box-action.test.mjs
+++ b/tests/unit/components/input-box-action.test.mjs
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { shouldHandleInputAction } from '../../../src/components/InputBox/input-action.mjs'
+
+test('input actions handle button clicks and both plain Enter forms', () => {
+  assert.equal(shouldHandleInputAction({ type: 'click' }), true)
+  assert.equal(
+    shouldHandleInputAction({ type: 'keydown', key: 'Enter', shiftKey: false }),
+    true,
+  )
+  assert.equal(
+    shouldHandleInputAction({ type: 'keydown', keyCode: 13, shiftKey: false }),
+    true,
+  )
+})
+
+test('input actions preserve Shift+Enter line breaks', () => {
+  assert.equal(
+    shouldHandleInputAction({ type: 'keydown', key: 'Enter', keyCode: 13, shiftKey: true }),
+    false,
+  )
+})
+
+test('input actions ignore directly exposed active IME composition', () => {
+  assert.equal(
+    shouldHandleInputAction({
+      type: 'keydown',
+      key: 'Enter',
+      keyCode: 13,
+      shiftKey: false,
+      isComposing: true,
+    }),
+    false,
+  )
+})
+
+test('input actions ignore active IME composition on synthetic native events', () => {
+  assert.equal(
+    shouldHandleInputAction({
+      type: 'keydown',
+      key: 'Enter',
+      keyCode: 13,
+      shiftKey: false,
+      nativeEvent: { isComposing: true },
+    }),
+    false,
+  )
+})
+
+test('input actions ignore the legacy IME keyCode 229 fallback', () => {
+  assert.equal(
+    shouldHandleInputAction({
+      type: 'keydown',
+      key: 'Enter',
+      keyCode: 229,
+      shiftKey: false,
+      isComposing: false,
+    }),
+    false,
+  )
+})
+
+test('input actions ignore unrelated keyboard events', () => {
+  assert.equal(
+    shouldHandleInputAction({ type: 'keydown', key: 'a', keyCode: 65, shiftKey: false }),
+    false,
+  )
+})


### PR DESCRIPTION
## Problem

CJK input methods commonly use Enter to confirm candidate text while composition is still active. The input box treated every unshifted Enter as a chat action, which could send incomplete text or stop an active response instead of confirming the IME candidate.

With Preact compat, composition state may be exposed on the synthetic event or its underlying native keyboard event. Some browser and IME combinations also use the legacy `keyCode` value 229.

## Changes

- Ignore Enter keydowns when either the direct or native event reports active composition.
- Cover the legacy `keyCode === 229` IME fallback.
- Preserve button clicks, modern and legacy plain Enter submission, and Shift+Enter line breaks.
- Test the `key` and `keyCode` Enter paths independently so either path cannot regress unnoticed.

## Validation

- `node --test tests/unit/components/input-box-action.test.mjs` — 6 tests passed.
- The combined focused suite for all five independent fixes — 39 tests passed.
- `node --check` passed for the changed JavaScript modules.
- Greptile and GitHub Copilot completed their amended-head reviews successfully with no new comments.