### PR TITLE
Add Grok 4.6 from SpaceXAI API

### DIFF
--- a/src/config/index.mjs
+++ b/src/config/index.mjs
@@ -192,7 +192,7 @@ export const googleApiModelKeys = [
   'googleGemini2_5Flash',
   'googleGemini2_5FlashLite',
 ]
-export const xaiApiModelKeys = ['xaiGrok4_5', 'xaiGrok4_3']
+export const xaiApiModelKeys = ['xaiGrok4_6', 'xaiGrok4_5', 'xaiGrok4_3']
 
 export const AlwaysCustomGroups = [
   'ollamaApiModelKeys',
@@ -691,6 +691,10 @@ export const Models = {
     value: 'gemini-2.5-flash-lite',
     desc: 'Google (Gemini 2.5 Flash-Lite)',
   },
+  xaiGrok4_6: {
+    value: 'grok-4.6',
+    desc: 'xAI (Grok 4.6)',
+  },
   xaiGrok4_5: {
     value: 'grok-4.5',
     desc: 'xAI (Grok 4.5)',
@@ -724,6 +728,7 @@ export const defaultApiModeIds = [
   'chatgptApi5_6Sol',
   'chatgptApi5_6Terra',
   'chatgptApi5_6Luna',
+  'xaiGrok4_6',
   'xaiGrok4_5',
   'claudeOpus5Api',
   'claudeSonnet5Api',

--- a/tests/unit/services/apis/provider-registry.test.mjs
+++ b/tests/unit/services/apis/provider-registry.test.mjs
@@ -2989,6 +2989,7 @@ test('resolveOpenAICompatibleRequest avoids duplicate /v1 for custom provider ba
 })
 
 test('resolveProviderIdForSession resolves legacy xAI model names to xai provider', () => {
+  assert.equal(resolveProviderIdForSession({ modelName: 'xaiGrok4_6' }), 'xai')
   assert.equal(resolveProviderIdForSession({ modelName: 'xaiGrok4_5' }), 'xai')
   assert.equal(resolveProviderIdForSession({ modelName: 'xaiApiModelKeys-custom' }), 'xai')
 })


### PR DESCRIPTION
Reference:
- https://x.ai/news/grok-4-6
- https://docs.x.ai/developers/grok-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the xAI Grok 4.6 model.
  * Grok 4.6 is now available in the default API model selection.

* **Bug Fixes**
  * Improved compatibility with the legacy `xaiGrok4_6` model name when connecting to xAI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->