### PR TITLE
Add latest & update the default Gemini Flash model(s)

### DIFF
--- a/src/config/index.mjs
+++ b/src/config/index.mjs
@@ -187,6 +187,9 @@ export const aimlApiModelKeys = [
 export const googleApiModelKeys = [
   'googleGemini3_1Pro',
   'googleGemini3_5Flash',
+  'googleGemini3_5FlashLite',
+  'googleGemini3_6Flash',
+  'googleGemini3_7Flash',
   'googleGemini3Flash',
   'googleGemini2_5Pro',
   'googleGemini2_5Flash',
@@ -675,6 +678,18 @@ export const Models = {
     value: 'gemini-3.5-flash',
     desc: 'Google (Gemini 3.5 Flash)',
   },
+  googleGemini3_5FlashLite: {
+    value: 'gemini-3.5-flash-lite',
+    desc: 'Google (Gemini 3.5 Flash-Lite)',
+  },
+  googleGemini3_6Flash: {
+    value: 'gemini-3.6-flash',
+    desc: 'Google (Gemini 3.6 Flash)',
+  },
+  googleGemini3_7Flash: {
+    value: 'gemini-3.7-flash',
+    desc: 'Google (Gemini 3.7 Flash)',
+  },
   googleGemini3Flash: {
     value: 'gemini-3-flash-preview',
     desc: 'Google (Gemini 3 Flash Preview)',
@@ -734,7 +749,7 @@ export const defaultApiModeIds = [
   'claudeSonnet5Api',
   'claudeHaiku45Api',
   'googleGemini3_1Pro',
-  'googleGemini3_5Flash',
+  'googleGemini3_7Flash',
   'mistralMediumLatest',
   'openRouter_auto',
   'openRouter_free',


### PR DESCRIPTION
## Summary

- Add Google Gemini 3.5 Flash-Lite (`gemini-3.5-flash-lite`).
- Add Google Gemini 3.6 Flash (`gemini-3.6-flash`).
- Add Google Gemini 3.7 Flash (`gemini-3.7-flash`).
- Update the default-enabled Google Flash model from Gemini 3.5 Flash to Gemini 3.7 Flash.
- Keep Gemini 3.1 Pro enabled by default.
- Keep Gemini 3.5 Flash, Gemini 3.5 Flash-Lite, and Gemini 3.6 Flash available for manual selection.

## Default behavior

For fresh installs and profiles that still use the live default API-mode list, the Google defaults change from Gemini 3.1 Pro + Gemini 3.5 Flash to Gemini 3.1 Pro + Gemini 3.7 Flash.

For materialized profiles with an existing default baseline, the existing reconciliation behavior is non-destructive: the new Gemini 3.7 Flash default can be appended, while an already materialized Gemini 3.5 Flash entry is not automatically removed or disabled. Older snapshots without a valid baseline continue to follow the existing conservative baseline-migration behavior. This preserves user choices instead of forcing a migration.

## References

- https://ai.google.dev/gemini-api/docs/models/gemini-3.7-flash
- https://ai.google.dev/gemini-api/docs/models

## Validation

- Rebuilt on the latest `master`.
- One file changed: `src/config/index.mjs`.
- `defaultApiModeIds` only replaces `googleGemini3_5Flash` with `googleGemini3_7Flash`; `googleGemini3_1Pro` remains unchanged.
- No provider-routing or request-parameter behavior is changed by this PR.
- Gemini temperature handling is covered by the already-merged opt-in temperature policy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for three new Google Gemini models: Gemini 3.5 Flash-Lite, Gemini 3.6 Flash, and Gemini 3.7 Flash.
  * Added model information for the new options.

* **Updates**
  * Updated the default model selection to include Gemini 3.7 Flash and remove two older models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->