### PR TITLE
Apply missed Prettier formatting updates

### DIFF
--- a/src/content-script/site-adapters/github/index.mjs
+++ b/src/content-script/site-adapters/github/index.mjs
@@ -1,10 +1,6 @@
 import { cropText, limitedFetch } from '../../../utils'
 import { config } from '../index.mjs'
-import {
-  hasGitHubPathChanged,
-  isGitHubIssuePath,
-  isGitHubPullPath,
-} from './path-matching.mjs'
+import { hasGitHubPathChanged, isGitHubIssuePath, isGitHubPullPath } from './path-matching.mjs'
 
 const getPatchUrl = async () => {
   const patchUrl = location.origin + location.pathname + '.patch'

--- a/src/utils/eventsource-parser.mjs
+++ b/src/utils/eventsource-parser.mjs
@@ -47,11 +47,7 @@ function createParser(onParse) {
       let lineLength = -1
       let fieldLength = startingFieldLength
       let character
-      for (
-        let index = position + startingPosition;
-        lineLength < 0 && index < length;
-        ++index
-      ) {
+      for (let index = position + startingPosition; lineLength < 0 && index < length; ++index) {
         character = buffer[index]
         if (character === ':' && fieldLength < 0) {
           fieldLength = index - position

--- a/tests/unit/components/input-box-action.test.mjs
+++ b/tests/unit/components/input-box-action.test.mjs
@@ -4,14 +4,8 @@ import { shouldHandleInputAction } from '../../../src/components/InputBox/input-
 
 test('input actions handle button clicks and both plain Enter forms', () => {
   assert.equal(shouldHandleInputAction({ type: 'click' }), true)
-  assert.equal(
-    shouldHandleInputAction({ type: 'keydown', key: 'Enter', shiftKey: false }),
-    true,
-  )
-  assert.equal(
-    shouldHandleInputAction({ type: 'keydown', keyCode: 13, shiftKey: false }),
-    true,
-  )
+  assert.equal(shouldHandleInputAction({ type: 'keydown', key: 'Enter', shiftKey: false }), true)
+  assert.equal(shouldHandleInputAction({ type: 'keydown', keyCode: 13, shiftKey: false }), true)
 })
 
 test('input actions preserve Shift+Enter line breaks', () => {


### PR DESCRIPTION
Bring three files back in line with the repository formatting output after they were missed by an earlier formatting pass.

This pull request consists of minor code cleanup and formatting improvements across several files. The main focus is on consolidating import statements and reformatting code for better readability, without changing any core logic or functionality.

Code formatting and cleanup:
	
* Consolidated multi-line import statements into single lines in `src/content-script/site-adapters/github/index.mjs` for improved readability.
* Reformatted the `for` loop declaration in `src/utils/eventsource-parser.mjs` to a single line for clarity.
* Combined multi-line `assert.equal` statements into single lines in `tests/unit/components/input-box-action.test.mjs` to make the tests more concise.

## Summary

- Apply Prettier formatting to three files that were missed by an earlier formatting pass
- Keep imports, loops, and test assertions consistent with the repository's formatting output
- No runtime behavior or test logic changes

## Validation

- `./node_modules/.bin/prettier --check` on changed files
- `npm run lint`
- `npm test` — 56 tests passed
- `npm run build`
- Manual browser smoke tests skipped because this is a formatting-only change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reformatted internal code for improved consistency and readability.
  * Updated test formatting without changing coverage or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->