### PR TITLE
Require repository-scoped GitHub thread paths

### DIFF
--- a/src/content-script/site-adapters/github/path-matching.mjs
+++ b/src/content-script/site-adapters/github/path-matching.mjs
@@ -1,5 +1,5 @@
-const issuePathPattern = /\/issues\/\d+\/?$/
-const pullPathPattern = /\/pull\/\d+\/?$/
+const issuePathPattern = /^\/[^/]+\/[^/]+\/issues\/\d+\/?$/
+const pullPathPattern = /^\/[^/]+\/[^/]+\/pull\/\d+\/?$/
 
 function normalizeGitHubPathname(pathname) {
   if (pathname === '/') return pathname

--- a/tests/unit/content-script/github-path-matching.test.mjs
+++ b/tests/unit/content-script/github-path-matching.test.mjs
@@ -13,6 +13,20 @@ test('GitHub thread paths allow an optional trailing slash', () => {
   assert.equal(isGitHubPullPath('/owner/repo/pull/456/'), true)
 })
 
+test('GitHub thread matching requires owner and repository path segments', () => {
+  assert.equal(isGitHubIssuePath('/owner-name/repo.name_1/issues/123'), true)
+  assert.equal(isGitHubPullPath('/owner-name/repo.name_1/pull/456'), true)
+
+  assert.equal(isGitHubIssuePath('/issues/123'), false)
+  assert.equal(isGitHubPullPath('/pull/456'), false)
+  assert.equal(isGitHubIssuePath('/owner/issues/123'), false)
+  assert.equal(isGitHubPullPath('/owner/pull/456'), false)
+  assert.equal(isGitHubIssuePath('/prefix/owner/repo/issues/123'), false)
+  assert.equal(isGitHubPullPath('/prefix/owner/repo/pull/456'), false)
+  assert.equal(isGitHubIssuePath('/owner/repo/nested/issues/123'), false)
+  assert.equal(isGitHubPullPath('/owner/repo/nested/pull/456'), false)
+})
+
 test('GitHub thread matching ignores query strings and fragments via pathname', () => {
   const issueUrl = new URL(
     'https://github.com/owner/repo/issues/123?notification_referrer_id=abc#issuecomment-456',


### PR DESCRIPTION
## Problem

The GitHub thread matchers currently accept any pathname that ends with `/issues/<number>` or `/pull/<number>`. Paths without a complete owner/repository prefix, or paths with additional leading or nested segments, can therefore be misclassified as repository issue or pull request threads.

## Changes

- Require issue and pull request paths to match the complete `/<owner>/<repository>/...` route shape.
- Keep the existing optional trailing-slash behavior unchanged.
- Avoid duplicating GitHub's owner and repository naming rules by validating path-segment boundaries only.
- Add regression coverage for valid punctuation, missing owner/repository segments, and additional leading or nested segments.

## Impact

This narrows the GitHub site adapter to standard repository-scoped thread routes without changing query, fragment, trailing-slash, or navigation-remount behavior.

## Validation

- `node --test tests/unit/content-script/github-path-matching.test.mjs` — 6 tests passed.
- First-party `pr-tests` passed:
  - coverage test suite
  - ESLint
  - production build
  - Safari build
  - Safari build artifact verification