### PR TITLE
Replace old josStorer/chatGPTBox namespace with ChatGPTBox-dev

### DIFF
--- a/scripts/submit-stores.mjs
+++ b/scripts/submit-stores.mjs
@@ -73,7 +73,7 @@ export function buildPublishExtensionArgs({ dryRun }) {
 }
 
 export function buildFirefoxReleaseNotes(version) {
-  return `https://github.com/josStorer/chatGPTBox/releases/tag/v${version}`
+  return `https://github.com/ChatGPTBox-dev/chatGPTBox/releases/tag/v${version}`
 }
 
 export function stripFirefoxExtensionId(extensionId) {

--- a/src/popup/Popup.jsx
+++ b/src/popup/Popup.jsx
@@ -135,10 +135,11 @@ function Popup() {
       i18n.changeLanguage(lang)
     })
     setCurrentVersion(Browser.runtime.getManifest().version.replace('v', ''))
-    fetch('https://api.github.com/repos/josstorer/chatGPTBox/releases/latest').then((response) =>
-      response.json().then((data) => {
-        setLatestVersion(data.tag_name.replace('v', ''))
-      }),
+    fetch('https://api.github.com/repos/ChatGPTBox-dev/chatGPTBox/releases/latest').then(
+      (response) =>
+        response.json().then((data) => {
+          setLatestVersion(data.tag_name.replace('v', ''))
+        }),
     )
     const initialConfigLoadGate = initialConfigLoadGateRef.current
     getUserConfig()

--- a/tests/unit/release/submit-stores.test.mjs
+++ b/tests/unit/release/submit-stores.test.mjs
@@ -111,7 +111,7 @@ test('buildPublishExtensionArgs includes all stores and dry run', () => {
 test('buildFirefoxReleaseNotes returns the fixed GitHub release URL', () => {
   assert.equal(
     buildFirefoxReleaseNotes('2.6.1'),
-    'https://github.com/josStorer/chatGPTBox/releases/tag/v2.6.1',
+    'https://github.com/ChatGPTBox-dev/chatGPTBox/releases/tag/v2.6.1',
   )
 })
 
@@ -165,7 +165,7 @@ test('updateFirefoxVersionNotes patches release notes and compatibility for the 
   assert.deepEqual(JSON.parse(calls[0].init.body), {
     compatibility: FIREFOX_COMPATIBILITY,
     release_notes: {
-      'en-US': 'https://github.com/josStorer/chatGPTBox/releases/tag/v2.6.1',
+      'en-US': 'https://github.com/ChatGPTBox-dev/chatGPTBox/releases/tag/v2.6.1',
     },
   })
 })


### PR DESCRIPTION
Somehow missing in #870 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Firefox release notes now link to the current ChatGPTBox GitHub repository.
  - The popup footer now checks the current repository for the latest available version.
  - Firefox store release information and links have been updated to reflect the repository change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->