### PR TITLE
Include native names and language tags in prompts

### DIFF
--- a/src/config/language.mjs
+++ b/src/config/language.mjs
@@ -1,7 +1,14 @@
-import { getUserConfig } from './index.mjs'
+import { getPreferredLanguageKey, getUserConfig } from './index.mjs'
 import { languageList } from './language-data.mjs'
 
 export { languageList }
+
+function formatLanguageForPrompt(languageKey) {
+  const { name, native } = languageList[languageKey]
+  return native && native !== name
+    ? `${name} (${native}; ${languageKey})`
+    : `${name} (${languageKey})`
+}
 
 export async function getUserLanguage() {
   const config = await getUserConfig()
@@ -14,15 +21,10 @@ export async function getUserLanguageNative() {
 }
 
 export async function getPreferredLanguage() {
-  const config = await getUserConfig()
-  const language =
-    config.preferredLanguage === 'auto' ? config.userLanguage : config.preferredLanguage
-  return languageList[language].name
+  return formatLanguageForPrompt(await getPreferredLanguageKey())
 }
 
 export async function getPreferredLanguageNative() {
-  const config = await getUserConfig()
-  const language =
-    config.preferredLanguage === 'auto' ? config.userLanguage : config.preferredLanguage
+  const language = await getPreferredLanguageKey()
   return languageList[language].native
 }

--- a/tests/unit/config/language-config.test.mjs
+++ b/tests/unit/config/language-config.test.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import { afterEach, beforeEach, test } from 'node:test'
 import Browser from 'webextension-polyfill'
 import { getPreferredLanguageKey, getUserConfig } from '../../../src/config/index.mjs'
+import { getPreferredLanguage } from '../../../src/config/language.mjs'
 
 const originalNavigatorDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'navigator')
 
@@ -95,6 +96,31 @@ test('auto resolves through the refreshed browser language', async () => {
   assert.equal(config.preferredLanguage, 'auto')
   assert.equal(config.userLanguage, 'zh-Hant')
   assert.equal(await getPreferredLanguageKey(), 'zh-Hant')
+})
+
+test('formats preferred language with native name and canonical tag for prompts', async () => {
+  globalThis.__TEST_BROWSER_SHIM__.replaceStorage({ preferredLanguage: 'zh-Hant' })
+
+  assert.equal(
+    await getPreferredLanguage(),
+    'Chinese (Traditional) (正體中文; zh-Hant)',
+  )
+})
+
+test('does not duplicate a native name that matches the English name', async () => {
+  globalThis.__TEST_BROWSER_SHIM__.replaceStorage({ preferredLanguage: 'en' })
+
+  assert.equal(await getPreferredLanguage(), 'English (en)')
+})
+
+test('formats auto preferred language from the current browser language', async () => {
+  setNavigatorLanguage('ja-JP')
+  globalThis.__TEST_BROWSER_SHIM__.replaceStorage({
+    preferredLanguage: 'auto',
+    userLanguage: 'en',
+  })
+
+  assert.equal(await getPreferredLanguage(), 'Japanese (日本語; ja)')
 })
 
 test('falls back arbitrary invalid preferences to the browser language', async () => {

--- a/tests/unit/content-script/selection-tools.test.mjs
+++ b/tests/unit/content-script/selection-tools.test.mjs
@@ -27,14 +27,14 @@ const wrappedBlock = (text) => `\n'''\n${text}\n'''`
 describe('selection-tools genPrompt', () => {
   test('explain includes language prefix and explanation instruction', async () => {
     const result = await config.explain.genPrompt('some concept')
-    assert.ok(result.startsWith('Reply in English.'))
+    assert.ok(result.startsWith('Reply in English (en).'))
     assert.ok(result.includes('Explain the following content'))
     assert.ok(result.endsWith(wrappedBlock('some concept')))
   })
 
   test('translate produces translation prompt with preferred language', async () => {
     const result = await config.translate.genPrompt('bonjour')
-    assert.ok(result.includes('Translate the following text into English'))
+    assert.ok(result.includes('Translate the following text into English (en)'))
     assert.ok(result.endsWith(wrappedBlock('bonjour')))
     // translate has no language prefix
     assert.ok(!result.startsWith('Reply in'))
@@ -55,14 +55,14 @@ describe('selection-tools genPrompt', () => {
 
   test('translateBidi includes bidirectional fallback instruction', async () => {
     const result = await config.translateBidi.genPrompt('hello')
-    assert.ok(result.includes('Translate the following text into English'))
+    assert.ok(result.includes('Translate the following text into English (en)'))
     assert.ok(result.includes('translate it into English instead'))
     assert.ok(result.endsWith(wrappedBlock('hello')))
   })
 
   test('summary includes summarization instruction with language prefix', async () => {
     const result = await config.summary.genPrompt('long article')
-    assert.ok(result.startsWith('Reply in English.'))
+    assert.ok(result.startsWith('Reply in English (en).'))
     assert.ok(result.includes('Summarize the following content'))
     assert.ok(result.endsWith(wrappedBlock('long article')))
   })
@@ -76,7 +76,7 @@ describe('selection-tools genPrompt', () => {
 
   test('sentiment includes language prefix and analysis instruction', async () => {
     const result = await config.sentiment.genPrompt('I love this')
-    assert.ok(result.startsWith('Reply in English.'))
+    assert.ok(result.startsWith('Reply in English (en).'))
     assert.ok(result.includes('sentiment analysis'))
     assert.ok(result.endsWith(wrappedBlock('I love this')))
   })
@@ -90,14 +90,14 @@ describe('selection-tools genPrompt', () => {
 
   test('code includes language prefix and code explanation instruction', async () => {
     const result = await config.code.genPrompt('const x = 1')
-    assert.ok(result.startsWith('Reply in English.'))
+    assert.ok(result.startsWith('Reply in English (en).'))
     assert.ok(result.includes('Break down the following code'))
     assert.ok(result.endsWith(wrappedBlock('const x = 1')))
   })
 
   test('ask includes language prefix', async () => {
     const result = await config.ask.genPrompt('why is the sky blue?')
-    assert.ok(result.startsWith('Reply in English.'))
+    assert.ok(result.startsWith('Reply in English (en).'))
     assert.ok(result.includes('Analyze the following content'))
     assert.ok(result.endsWith(wrappedBlock('why is the sky blue?')))
   })
@@ -109,14 +109,14 @@ describe('translation tools respect language settings', () => {
   test('translate uses preferred language from config', async () => {
     globalThis.__TEST_BROWSER_SHIM__.setStorage({ preferredLanguage: 'ja' })
     const result = await config.translate.genPrompt('hello')
-    assert.ok(result.includes('Translate the following text into Japanese'))
+    assert.ok(result.includes('Translate the following text into Japanese (日本語; ja)'))
   })
 
   test('translate falls back to navigator language when preference is auto', async () => {
     globalThis.__TEST_BROWSER_SHIM__.setStorage({ preferredLanguage: 'auto' })
     const result = await config.translate.genPrompt('hello')
     // navigator.language is 'en-US' via browser shim → userLanguage 'en' → English
-    assert.ok(result.includes('Translate the following text into English'))
+    assert.ok(result.includes('Translate the following text into English (en)'))
   })
 
   test('translateToEn ignores preferred language', async () => {
@@ -136,7 +136,13 @@ describe('translation tools respect language settings', () => {
   test('explain language prefix reflects preferred language', async () => {
     globalThis.__TEST_BROWSER_SHIM__.setStorage({ preferredLanguage: 'fr' })
     const result = await config.explain.genPrompt('text')
-    assert.ok(result.startsWith('Reply in French.'))
+    assert.ok(result.startsWith('Reply in French (Français; fr).'))
+  })
+
+  test('Traditional Chinese includes native name and canonical language tag', async () => {
+    globalThis.__TEST_BROWSER_SHIM__.setStorage({ preferredLanguage: 'zh-Hant' })
+    const result = await config.explain.genPrompt('text')
+    assert.ok(result.startsWith('Reply in Chinese (Traditional) (正體中文; zh-Hant).'))
   })
 })
 
@@ -162,8 +168,8 @@ describe('bidirectional translation toggle', () => {
   test('translateBidi uses preferred language in bidirectional clause', async () => {
     globalThis.__TEST_BROWSER_SHIM__.setStorage({ preferredLanguage: 'ja' })
     const result = await config.translateBidi.genPrompt('text')
-    assert.ok(result.includes('into Japanese'))
-    assert.ok(result.includes('If the text is already in Japanese'))
+    assert.ok(result.includes('into Japanese (日本語; ja)'))
+    assert.ok(result.includes('If the text is already in Japanese (日本語; ja)'))
   })
 })
 


### PR DESCRIPTION
## Problem

Preferred-language prompt instructions currently identify the target language only by its English display name, for example `Reply in Chinese (Traditional).`. This can be ambiguous for closely related language/script variants and gives the model less direct target-language context than the language metadata already available in ChatGPTBox.

## Changes

- Format preferred languages in prompts with their English name, native name, and canonical BCP 47 tag.
- Omit a duplicate native name when it is identical to the English name, so English becomes `English (en)` rather than `English (English; en)`.
- Resolve `auto` through the existing canonical preferred-language key before formatting.
- Keep fixed translation targets such as `Translate (To English)` and `Translate (To Chinese)` unchanged.
- Centralize the richer representation in `getPreferredLanguage()`. Its current production callers are all prompt-generation paths, so search/site prompts, context-menu prompts, and preferred-language selection tools receive the same representation without duplicating formatting logic.

Examples:

- `Chinese (Traditional) (正體中文; zh-Hant)`
- `Chinese (Simplified) (简体中文; zh-Hans)`
- `Japanese (日本語; ja)`
- `French (Français; fr)`
- `English (en)`

## Scope

This does not change language storage, locale resolution, UI language selection, provider request schemas, shared provider system prompts, or dependencies. It builds directly on the canonical BCP 47 language keys already present on `master`.

## Validation

Regression coverage verifies:

- native name + canonical tag formatting
- English native-name deduplication
- `auto` browser-language resolution
- English, Japanese, French, and Traditional Chinese prompt output
- preferred-language translation and bidirectional translation prompts
- unchanged fixed English/Chinese translation targets

Current-head PR CI passed:

- `npm run test:coverage`
- `npm run lint`
- `npm run build`
- `npm run build:safari`
- Safari build artifact verification

Automated review status:

- Devin Review: success
- CodeRabbit: success
- Qodo high-level assessment: no actionable issue; it explicitly supports centralizing prompt-specific formatting in `getPreferredLanguage()`
- Inline review threads: none

The branch remains a single commit directly on the latest `master` used when the PR was created.