### PR TITLE
Use clearer English names for Chinese variants

### DIFF
--- a/src/config/language-data.mjs
+++ b/src/config/language-data.mjs
@@ -9,12 +9,12 @@ export const languageList = {
   ...baseLanguages,
   'zh-Hans': {
     ...zh,
-    name: 'Chinese (Simplified)',
+    name: 'Simplified Chinese',
     native: '简体中文',
   },
   'zh-Hant': {
     ...zh,
-    name: 'Chinese (Traditional)',
+    name: 'Traditional Chinese',
     native: '正體中文',
   },
 }

--- a/tests/unit/config/language-config.test.mjs
+++ b/tests/unit/config/language-config.test.mjs
@@ -103,7 +103,7 @@ test('formats preferred language with native name and canonical tag for prompts'
 
   assert.equal(
     await getPreferredLanguage(),
-    'Chinese (Traditional) (正體中文; zh-Hant)',
+    'Traditional Chinese (正體中文; zh-Hant)',
   )
 })
 

--- a/tests/unit/config/language-data.test.mjs
+++ b/tests/unit/config/language-data.test.mjs
@@ -35,9 +35,9 @@ test('language list uses canonical keys for Chinese and Indonesian', () => {
 })
 
 test('Chinese entries preserve explicit script-specific names', () => {
-  assert.equal(languageList['zh-Hans'].name, 'Chinese (Simplified)')
+  assert.equal(languageList['zh-Hans'].name, 'Simplified Chinese')
   assert.equal(languageList['zh-Hans'].native, '简体中文')
-  assert.equal(languageList['zh-Hant'].name, 'Chinese (Traditional)')
+  assert.equal(languageList['zh-Hant'].name, 'Traditional Chinese')
   assert.equal(languageList['zh-Hant'].native, '正體中文')
 })
 

--- a/tests/unit/content-script/selection-tools.test.mjs
+++ b/tests/unit/content-script/selection-tools.test.mjs
@@ -142,7 +142,7 @@ describe('translation tools respect language settings', () => {
   test('Traditional Chinese includes native name and canonical language tag', async () => {
     globalThis.__TEST_BROWSER_SHIM__.setStorage({ preferredLanguage: 'zh-Hant' })
     const result = await config.explain.genPrompt('text')
-    assert.ok(result.startsWith('Reply in Chinese (Traditional) (正體中文; zh-Hant).'))
+    assert.ok(result.startsWith('Reply in Traditional Chinese (正體中文; zh-Hant).'))
   })
 })
 


### PR DESCRIPTION
## Problem

The English names for the two Chinese script variants currently use the parenthetical forms `Chinese (Simplified)` and `Chinese (Traditional)`.

`Simplified Chinese` and `Traditional Chinese` are clearer, more natural standalone language names. This naming issue exists independently of how the names are later used in prompts or other consumers.

## Changes

- Rename `Chinese (Simplified)` to `Simplified Chinese`.
- Rename `Chinese (Traditional)` to `Traditional Chinese`.
- Update only the existing metadata and prompt-output expectations affected by those two renamed values.

For example, prompt labels that consume this metadata now become:

- `Simplified Chinese (简体中文; zh-Hans)`
- `Traditional Chinese (正體中文; zh-Hant)`

## Scope

This is a display-name cleanup only. Native names, canonical language keys (`zh-Hans` / `zh-Hant`), locale resolution, stored preferences, formatter behavior, and fixed translation-tool behavior are unchanged.

The English `name` field remains model-facing metadata rather than localized UI copy. The language selector continues to display each entry's `native` value.

The final diff is intentionally minimal:

- `src/config/language-data.mjs`: 2 name replacements
- `tests/unit/config/language-data.test.mjs`: 2 metadata expectation replacements
- `tests/unit/config/language-config.test.mjs`: 1 existing prompt expectation replacement
- `tests/unit/content-script/selection-tools.test.mjs`: 1 existing prompt expectation replacement

## Validation

Current-head CI passed:

- `npm run test:coverage`
- `npm run lint`
- `npm run build`
- `npm run build:safari`
- Safari build artifact verification

Automated review results on the cleaned-up head:

- Pullfrog: approved with no outstanding concerns
- Copilot: the suggestion to duplicate `zh-Hans` prompt-format coverage was reviewed and declined as redundant because both metadata names are already asserted directly and the formatter has no variant-specific branch; thread resolved
- CodeRabbit: success with no actionable comments
- Qodo: its localization concern was reviewed, answered, dismissed, and resolved because these stable English names are model-facing metadata while the UI renders native names
- Inline review threads: all resolved

The branch is a single clean commit directly on the current `master`; the temporary stray-file commit seen during cleanup was dropped entirely from branch history.