### PR TITLE
Add OpenRouter Fusion Flash model support

### DIFF
--- a/src/config/index.mjs
+++ b/src/config/index.mjs
@@ -152,6 +152,7 @@ export const openRouterApiModelKeys = [
   'openRouter_openai_o3',
   'openRouter_openai_gpt_4_1_mini',
   'openRouter_fusion',
+  'openRouter_fusion_flash',
   'openRouter_openai_gpt_chat_latest',
   'openRouter_openai_gpt_5_5',
   'openRouter_openai_gpt_5_5_pro',
@@ -515,6 +516,10 @@ export const Models = {
   openRouter_fusion: {
     value: 'openrouter/fusion',
     desc: 'OpenRouter (Fusion)',
+  },
+  openRouter_fusion_flash: {
+    value: 'openrouter/fusion-flash',
+    desc: 'OpenRouter (Fusion Flash)',
   },
   openRouter_openai_gpt_chat_latest: {
     value: 'openai/gpt-chat-latest',

--- a/tests/unit/services/apis/thin-adapters.test.mjs
+++ b/tests/unit/services/apis/thin-adapters.test.mjs
@@ -68,10 +68,11 @@ const adapters = [
   },
   {
     name: 'openrouter-api',
-    apiMode: { groupName: 'openRouterApiModelKeys', itemName: 'openRouter_openai_o3' },
+    apiMode: { groupName: 'openRouterApiModelKeys', itemName: 'openRouter_fusion_flash' },
     providerId: 'openrouter',
     expectedBaseUrl: 'https://openrouter.ai/api/v1',
     expectedApiKey: 'or-key',
+    expectedModel: 'openrouter/fusion-flash',
   },
   {
     name: 'chatglm-api',
@@ -116,6 +117,9 @@ for (const adapter of adapters) {
     assert.equal(capturedInput, `${adapter.expectedBaseUrl}/chat/completions`)
     // Verify API key reaches the Authorization header
     assert.equal(capturedInit.headers.Authorization, `Bearer ${adapter.expectedApiKey}`)
+    if (adapter.expectedModel) {
+      assert.equal(JSON.parse(capturedInit.body).model, adapter.expectedModel)
+    }
   })
 
   test(`${adapter.name}: delegates to compat layer and produces output`, async (t) => {


### PR DESCRIPTION
## Summary

- Add `openrouter/fusion-flash` to the OpenRouter API model picker.
- Verify the exact model ID reaches the OpenRouter Chat Completions request body.

## Validation

- `npm test`
- `npm run lint`
- `npm run build`
- Manual browser smoke test not run: no Chromium or Firefox executable is available in this environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting the OpenRouter Fusion Flash model.

* **Tests**
  * Updated OpenRouter coverage to validate Fusion Flash model requests.
  * Added verification that configured model identifiers are included in request payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->