### PR TITLE
Add Gemini 3.8 Flash & update the default Gemini Flash model

### DIFF
--- a/src/config/index.mjs
+++ b/src/config/index.mjs
@@ -196,6 +196,7 @@ export const googleApiModelKeys = [
   'googleGemini3_5FlashLite',
   'googleGemini3_6Flash',
   'googleGemini3_7Flash',
+  'googleGemini3_8Flash',
   'googleGemini3Flash',
   'googleGemini2_5Pro',
   'googleGemini2_5Flash',
@@ -696,6 +697,10 @@ export const Models = {
     value: 'gemini-3.7-flash',
     desc: 'Google (Gemini 3.7 Flash)',
   },
+  googleGemini3_8Flash: {
+    value: 'gemini-3.8-flash',
+    desc: 'Google (Gemini 3.8 Flash)',
+  },
   googleGemini3Flash: {
     value: 'gemini-3-flash-preview',
     desc: 'Google (Gemini 3 Flash Preview)',
@@ -755,7 +760,7 @@ export const defaultApiModeIds = [
   'claudeSonnet5Api',
   'claudeHaiku45Api',
   'googleGemini3_1Pro',
-  'googleGemini3_7Flash',
+  'googleGemini3_8Flash',
   'mistralMediumLatest',
   'openRouter_auto',
   'openRouter_free',


### PR DESCRIPTION
## Summary

- Add Google Gemini 3.8 Flash (`gemini-3.8-flash`) to the built-in Google API model presets.
- Update the default-enabled Google Flash model from Gemini 3.7 Flash to Gemini 3.8 Flash.
- Keep Gemini 3.7 Flash available for explicit selection.
- Keep Gemini 3.1 Pro Preview enabled by default.

This uses the existing built-in Google provider and its Gemini API OpenAI-compatible endpoint, so no provider routing or request handling changes are needed.

## References

- Gemini 3.8 Flash announcement: https://blog.google/innovation-and-ai/models-and-research/gemini-models/3-8-flash-and-3-8-flash-cyber/
- Gemini 3.8 Flash model documentation: https://ai.google.dev/gemini-api/docs/models/gemini-3.8-flash
- Gemini API OpenAI compatibility: https://ai.google.dev/gemini-api/docs/openai


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Google Gemini 3.8 Flash.
  * Updated the default model selection to use Gemini 3.8 Flash instead of Gemini 3.7 Flash.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->