### PR TITLE
Add Anthropic Claude Fable 5 and 5.1 API support

### DIFF
--- a/src/_locales/en/main.json
+++ b/src/_locales/en/main.json
@@ -197,6 +197,8 @@
   "Anthropic (Claude 3 Haiku)": "Anthropic (Claude 3 Haiku)",
   "Anthropic (Claude 3.5 Haiku)": "Anthropic (Claude 3.5 Haiku)",
   "Anthropic (Claude 3.7 Sonnet)": "Anthropic (Claude 3.7 Sonnet)",
+  "Anthropic (Claude Fable 5)": "Anthropic (Claude Fable 5)",
+  "Anthropic (Claude Fable 5.1)": "Anthropic (Claude Fable 5.1)",
   "Anthropic (Claude Opus 4)": "Anthropic (Claude Opus 4)",
   "Anthropic (Claude Opus 4.1)": "Anthropic (Claude Opus 4.1)",
   "Anthropic (Claude Opus 4.5)": "Anthropic (Claude Opus 4.5)",

--- a/src/config/index.mjs
+++ b/src/config/index.mjs
@@ -92,6 +92,8 @@ export const customApiModelKeys = ['customModel']
 export const ollamaApiModelKeys = ['ollamaModel']
 export const azureOpenAiApiModelKeys = ['azureOpenAi']
 export const claudeApiModelKeys = [
+  'claudeFable5Api',
+  'claudeFable51Api',
   'claudeOpus41Api',
   'claudeOpus45Api',
   'claudeOpus46Api',
@@ -340,6 +342,14 @@ export const Models = {
   chatgptApi4_1_nano: { value: 'gpt-4.1-nano', desc: 'OpenAI (GPT-4.1 nano)' },
 
   claude2WebFree: { value: '', desc: 'Claude.ai (Web)' },
+  claudeFable5Api: {
+    value: 'claude-fable-5',
+    desc: 'Anthropic (Claude Fable 5)',
+  },
+  claudeFable51Api: {
+    value: 'claude-fable-5-1',
+    desc: 'Anthropic (Claude Fable 5.1)',
+  },
   claudeOpus41Api: {
     value: 'claude-opus-4-1-20250805',
     desc: 'Anthropic (Claude Opus 4.1)',
@@ -754,6 +764,7 @@ export const defaultApiModeIds = [
   'chatgptApi6Astra',
   'xaiGrok4_6',
   'xaiGrok4_5',
+  'claudeFable51Api',
   'claudeOpus5Api',
   'claudeSonnet5Api',
   'claudeHaiku45Api',

--- a/src/services/apis/temperature-params.mjs
+++ b/src/services/apis/temperature-params.mjs
@@ -3,6 +3,8 @@ const MODELS_WITHOUT_CUSTOM_TEMPERATURE = new Set([
   'claude-opus-4-8',
   'claude-sonnet-5',
   'claude-opus-5',
+  'claude-fable-5',
+  'claude-fable-5-1',
   'gpt-6-astra',
 ])
 

--- a/tests/unit/services/apis/claude-api.test.mjs
+++ b/tests/unit/services/apis/claude-api.test.mjs
@@ -178,6 +178,8 @@ test('claude-api: omits temperature for models that reject custom sampling', asy
   t.mock.method(console, 'debug', () => {})
 
   for (const [modelName, model] of [
+    ['claudeFable5Api', 'claude-fable-5'],
+    ['claudeFable51Api', 'claude-fable-5-1'],
     ['claudeOpus47Api', 'claude-opus-4-7'],
     ['claudeOpus48Api', 'claude-opus-4-8'],
     ['claudeOpus5Api', 'claude-opus-5'],

--- a/tests/unit/services/apis/temperature-params.test.mjs
+++ b/tests/unit/services/apis/temperature-params.test.mjs
@@ -35,6 +35,9 @@ test('temperature overrides omit known Anthropic models across provider ID forma
     'claude-opus-4-8-20260801',
     'claude-sonnet-5',
     'claude-opus-5',
+    'claude-fable-5',
+    'claude-fable-5-1',
+    'anthropic/claude-fable-5.1',
   ]) {
     assert.equal(canApplyTemperatureOverride(model), false, model)
     assert.deepEqual(


### PR DESCRIPTION
Expose Claude Fable 5 and Claude Fable 5.1 through the official Anthropic API model list using the documented `claude-fable-5` and `claude-fable-5-1` identifiers.

## Changes

- Register Claude Fable 5 and Claude Fable 5.1 as selectable Anthropic API models with their English source labels.
- Keep the Fable family in version order (5, then 5.1), consistent with recent same-family model additions.
- Enable Fable 5.1 in the default API model set while keeping Fable 5 available as a separate selectable model.
- Preserve both models' always-on adaptive thinking behavior by leaving `thinking` unset.
- Omit unsupported custom `temperature` overrides for both Fable model families.
- Extend the existing Claude request-shaping and shared temperature regression coverage instead of maintaining a separate Fable test harness.

## Validation

- Rebased the single Fable commit onto the current `master` (`dd14c3189ad2971584a00848aeb7a0780c9fa929`) and resolved the overlapping model/temperature changes while preserving the newer GPT-6 Astra updates.
- Reviewed the final diff: 5 files changed, 20 additions, 0 deletions, with no release-note or Claude API transport changes.
- Covered both Fable model IDs, adaptive-thinking request shaping, temperature override handling, and provider-qualified model normalization.

## References

- https://www.anthropic.com/news/claude-fable-5-mythos-5
- https://www.anthropic.com/claude-fable-and-mythos-5-1
- https://platform.claude.com/docs/en/models/fable-5/introducing-claude-fable-5-and-claude-mythos-5
- https://platform.claude.com/docs/en/models/fable-5-1/overview
- https://platform.claude.com/docs/en/models/fable-5/migration-guide
- https://platform.claude.com/docs/en/claude_api_primer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for Anthropic Claude Fable 5 and Claude Fable 5.1 models.
  - Added support for the ChatGPT 6 Astra model.
  - Claude Fable 5.1 and ChatGPT 6 Astra are now included among the default available models.
  - Added English localization for both Claude model names.

- **Bug Fixes**
  - Prevented unsupported custom temperature settings from being sent to applicable models.

- **Tests**
  - Expanded coverage for the new models and temperature-handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->