### PR TITLE
Add OpenAI GPT-6 Astra support

### DIFF
--- a/src/_locales/en/main.json
+++ b/src/_locales/en/main.json
@@ -223,6 +223,7 @@
   "OpenAI (GPT-5.6 Sol)": "OpenAI (GPT-5.6 Sol)",
   "OpenAI (GPT-5.6 Terra)": "OpenAI (GPT-5.6 Terra)",
   "OpenAI (GPT-5.6 Luna)": "OpenAI (GPT-5.6 Luna)",
+  "OpenAI (GPT-6 Astra)": "OpenAI (GPT-6 Astra)",
   "Anthropic (Claude Sonnet 4.6)": "Anthropic (Claude Sonnet 4.6)",
   "This provider is still used by other API modes or saved conversations": "This provider is still used by other API modes or saved conversations",
   "This API key is set on the selected custom mode. Editing it here will create a dedicated provider for that mode.": "This API key is set on the selected custom mode. Editing it here will create a dedicated provider for that mode.",

--- a/src/config/index.mjs
+++ b/src/config/index.mjs
@@ -82,6 +82,7 @@ export const chatgptApiModelKeys = [
   'chatgptApi5_6Sol',
   'chatgptApi5_6Terra',
   'chatgptApi5_6Luna',
+  'chatgptApi6Astra',
   'chatgptApi4oMini',
   'chatgptApi4_1',
   'chatgptApi4_1_mini',
@@ -332,6 +333,7 @@ export const Models = {
   chatgptApi5_6Sol: { value: 'gpt-5.6-sol', desc: 'OpenAI (GPT-5.6 Sol)' },
   chatgptApi5_6Terra: { value: 'gpt-5.6-terra', desc: 'OpenAI (GPT-5.6 Terra)' },
   chatgptApi5_6Luna: { value: 'gpt-5.6-luna', desc: 'OpenAI (GPT-5.6 Luna)' },
+  chatgptApi6Astra: { value: 'gpt-6-astra', desc: 'OpenAI (GPT-6 Astra)' },
 
   chatgptApi4_1: { value: 'gpt-4.1', desc: 'OpenAI (GPT-4.1)' },
   chatgptApi4_1_mini: { value: 'gpt-4.1-mini', desc: 'OpenAI (GPT-4.1 mini)' },
@@ -749,6 +751,7 @@ export const defaultApiModeIds = [
   'chatgptApi5_6Sol',
   'chatgptApi5_6Terra',
   'chatgptApi5_6Luna',
+  'chatgptApi6Astra',
   'xaiGrok4_6',
   'xaiGrok4_5',
   'claudeOpus5Api',

--- a/src/services/apis/openai-token-params.mjs
+++ b/src/services/apis/openai-token-params.mjs
@@ -1,4 +1,5 @@
-const OPENAI_MAX_COMPLETION_TOKENS_MODEL_PATTERN = /^(?:gpt-5(?:[.-]|$)|chat-latest$)/
+const OPENAI_MAX_COMPLETION_TOKENS_MODEL_PATTERN =
+  /^(?:gpt-5(?:[.-]|$)|gpt-6-astra(?:-|$)|chat-latest$)/
 
 function shouldUseMaxCompletionTokens(provider, model) {
   const normalizedProvider = String(provider || '').toLowerCase()

--- a/src/services/apis/temperature-params.mjs
+++ b/src/services/apis/temperature-params.mjs
@@ -3,13 +3,14 @@ const MODELS_WITHOUT_CUSTOM_TEMPERATURE = new Set([
   'claude-opus-4-8',
   'claude-sonnet-5',
   'claude-opus-5',
+  'gpt-6-astra',
 ])
 
 function normalizeModelId(model) {
   return String(model || '')
     .trim()
     .toLowerCase()
-    .replace(/^(?:anthropic|google)\//, '')
+    .replace(/^(?:anthropic|google|openai)\//, '')
     .replace(/\./g, '-')
 }
 

--- a/tests/unit/services/apis/openai-api-compat.test.mjs
+++ b/tests/unit/services/apis/openai-api-compat.test.mjs
@@ -751,6 +751,44 @@ test('generateAnswersWithOpenAiApi uses max_completion_tokens for GPT-5.4 mini',
   assert.equal(Object.hasOwn(body, 'max_tokens'), false)
 })
 
+test('generateAnswersWithOpenAiApi uses max_completion_tokens for GPT-6 Astra and omits unsupported temperature', async (t) => {
+  t.mock.method(console, 'debug', () => {})
+  setStorage({
+    customOpenAiApiUrl: 'https://api.openai.example.com',
+    maxConversationContextLength: 3,
+    maxResponseTokenLength: 444,
+    temperatureOverrideEnabled: true,
+    temperature: 0.3,
+  })
+
+  const session = {
+    modelName: 'chatgptApi6Astra',
+    conversationRecords: [],
+    isRetry: false,
+  }
+  const port = createFakePort()
+
+  let capturedInput
+  let capturedInit
+  t.mock.method(globalThis, 'fetch', async (input, init) => {
+    capturedInput = input
+    capturedInit = init
+    return createMockSseResponse([
+      'data: {"choices":[{"delta":{"content":"OK"},"finish_reason":"stop"}]}\n\n',
+    ])
+  })
+
+  await generateAnswersWithOpenAiApi(port, 'CurrentQ', session, 'sk-test')
+
+  const body = JSON.parse(capturedInit.body)
+  assert.equal(capturedInput, 'https://api.openai.example.com/v1/chat/completions')
+  assert.equal(body.model, 'gpt-6-astra')
+  assert.equal(body.max_completion_tokens, 444)
+  assert.equal(Object.hasOwn(body, 'max_tokens'), false)
+  assert.equal(Object.hasOwn(body, 'temperature'), false)
+  assert.equal(session.conversationRecords.at(-1).answer, 'OK')
+})
+
 test('generateAnswersWithOpenAiApi uses max_completion_tokens for GPT-5.4 nano', async (t) => {
   t.mock.method(console, 'debug', () => {})
   setStorage({

--- a/tests/unit/services/apis/openai-token-params.test.mjs
+++ b/tests/unit/services/apis/openai-token-params.test.mjs
@@ -88,3 +88,19 @@ test('uses max_tokens when provider is undefined', () => {
     max_tokens: 259,
   })
 })
+
+test('uses completion token limits only for OpenAI GPT-6 Astra models', () => {
+  for (const model of ['gpt-6-astra', 'gpt-6-astra-20260901', 'GPT-6-ASTRA']) {
+    assert.deepEqual(getChatCompletionsTokenParams('openai', model, 1024), {
+      max_completion_tokens: 1024,
+    })
+    assert.deepEqual(getChatCompletionsTokenParams('some-proxy-provider', model, 1024), {
+      max_tokens: 1024,
+    })
+  }
+  for (const model of ['gpt-6-astral', 'my-gpt-6-astra', 'gpt-60', 'openai/gpt-6-astra']) {
+    assert.deepEqual(getChatCompletionsTokenParams('openai', model, 1024), {
+      max_tokens: 1024,
+    })
+  }
+})

--- a/tests/unit/services/apis/temperature-params.test.mjs
+++ b/tests/unit/services/apis/temperature-params.test.mjs
@@ -97,3 +97,22 @@ test('temperature overrides remain available for earlier Gemini models', () => {
     )
   }
 })
+
+test('temperature overrides omit GPT-6 Astra across provider ID formats', () => {
+  for (const model of [
+    'gpt-6-astra',
+    'openai/gpt-6-astra',
+    'GPT-6-ASTRA',
+    'gpt-6-astra-20260901',
+  ]) {
+    assert.equal(canApplyTemperatureOverride(model), false, model)
+    assert.deepEqual(
+      getTemperatureParams({ temperatureOverrideEnabled: true, temperature: 0.7 }, model),
+      {},
+      model,
+    )
+  }
+  for (const model of ['gpt-6-astral', 'my-gpt-6-astra', 'gpt-4.1']) {
+    assert.equal(canApplyTemperatureOverride(model), true, model)
+  }
+})


### PR DESCRIPTION
- Add GPT-6 Astra to the available and default OpenAI API modes.
- Use completion token limits and omit custom temperature values.
- Cover model matching and streaming request parameters with tests.

References:
- https://openai.com/index/gpt-6-astra/
- https://developers.openai.com/api/docs/models/gpt-6-astra

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenAI GPT-6 Astra as an available model.
  * Added localized display text for GPT-6 Astra.
  * Configured GPT-6 Astra for compatible token handling and temperature settings.

* **Bug Fixes**
  * Improved recognition of GPT-6 Astra model variants and provider-prefixed identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->