### PR TITLE
Fix prettier formatting in config and language tests

### DIFF
--- a/src/config/index.mjs
+++ b/src/config/index.mjs
@@ -18,10 +18,7 @@ import {
   canonicalizeModelKey,
   canonicalizeModelKeyArray,
 } from './model-key-migrations.mjs'
-import {
-  getNavigatorLanguage,
-  resolvePreferredLanguageKey,
-} from './language-data.mjs'
+import { getNavigatorLanguage, resolvePreferredLanguageKey } from './language-data.mjs'
 
 export { getNavigatorLanguage }
 

--- a/tests/unit/components/read-button-voice.test.mjs
+++ b/tests/unit/components/read-button-voice.test.mjs
@@ -34,10 +34,7 @@ test('findMatchingVoice prefers the vendor voice within the matching script', ()
   const genericSimplified = { name: 'Generic Simplified', lang: 'zh-CN' }
   const xiaoyi = { name: 'Microsoft Xiaoyi Online', lang: 'zh-CN' }
 
-  assert.equal(
-    findMatchingVoice([genericSimplified, xiaoyi], 'zh-Hans', 'xiaoyi'),
-    xiaoyi,
-  )
+  assert.equal(findMatchingVoice([genericSimplified, xiaoyi], 'zh-Hans', 'xiaoyi'), xiaoyi)
 })
 
 test('findMatchingVoice normalizes the preferred vendor name', () => {
@@ -50,10 +47,7 @@ test('findMatchingVoice does not let a vendor voice override the requested scrip
   const xiaoyiSimplified = { name: 'Microsoft Xiaoyi Online', lang: 'zh-CN' }
   const traditional = { name: 'Traditional Chinese', lang: 'zh-TW' }
 
-  assert.equal(
-    findMatchingVoice([xiaoyiSimplified, traditional], 'zh-Hant', 'xiaoyi'),
-    traditional,
-  )
+  assert.equal(findMatchingVoice([xiaoyiSimplified, traditional], 'zh-Hant', 'xiaoyi'), traditional)
 })
 
 test('findMatchingVoice falls back to the base language', () => {

--- a/tests/unit/config/language-config.test.mjs
+++ b/tests/unit/config/language-config.test.mjs
@@ -101,10 +101,7 @@ test('auto resolves through the refreshed browser language', async () => {
 test('formats preferred language with native name and canonical tag for prompts', async () => {
   globalThis.__TEST_BROWSER_SHIM__.replaceStorage({ preferredLanguage: 'zh-Hant' })
 
-  assert.equal(
-    await getPreferredLanguage(),
-    'Traditional Chinese (正體中文; zh-Hant)',
-  )
+  assert.equal(await getPreferredLanguage(), 'Traditional Chinese (正體中文; zh-Hant)')
 })
 
 test('does not duplicate a native name that matches the English name', async () => {


### PR DESCRIPTION
Missing in some previous changes; should use CI to prevent it from happening again.

## GitHub Copilot PR Summary

This pull request primarily refactors code for improved readability and consistency by consolidating import statements and reformatting test assertions to single lines. No functional changes are introduced.

Code cleanup and formatting:

* Consolidated multi-line import statements into single lines in `src/config/index.mjs` to improve readability.
* Reformatted multi-line assertion statements into single lines in `tests/unit/components/read-button-voice.test.mjs` and `tests/unit/config/language-config.test.mjs` for consistency and clarity. [[1]](diffhunk://#diff-a68526b31876fa22993efd0470a14569c17950b15238feee6b97fa54e494d8bdL37-R37) [[2]](diffhunk://#diff-a68526b31876fa22993efd0470a14569c17950b15238feee6b97fa54e494d8bdL53-R50) [[3]](diffhunk://#diff-4d87eec99f84226388d9b6cbd44a8f1ee3808eef26e21a60983db314b4a10511L104-R104)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reformatted configuration and test code for improved consistency and readability.
  * No functional or user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->