### PR TITLE
Reset SSE parser metadata state

### DIFF
--- a/src/utils/eventsource-parser.mjs
+++ b/src/utils/eventsource-parser.mjs
@@ -25,6 +25,7 @@ function createParser(onParse) {
     eventId = void 0
     eventName = void 0
     data = ''
+    extra = void 0
     discardTrailingNewline = false
   }
 

--- a/tests/unit/utils/eventsource-parser.test.mjs
+++ b/tests/unit/utils/eventsource-parser.test.mjs
@@ -193,6 +193,25 @@ test('createParser reset discards pending decoder bytes', () => {
   )
 })
 
+test('createParser reset discards pending event metadata', () => {
+  const parsed = []
+  const parser = createParser((event) => parsed.push(event))
+
+  parser.feed(toBytes('meta: {"source":"stale"}\n'))
+  parser.reset()
+  parser.feed(toBytes('data: clean\n\n'))
+
+  assert.deepEqual(parsed, [
+    {
+      type: 'event',
+      id: undefined,
+      event: undefined,
+      data: 'clean',
+      extra: undefined,
+    },
+  ])
+})
+
 test('createParser handles \\r only line endings', () => {
   const parsed = []
   const parser = createParser((event) => parsed.push(event))


### PR DESCRIPTION
## Summary

- Clear pending `extra` metadata when `createParser().reset()` is called.
- Add a regression test that feeds `meta` state, resets the parser, and verifies the next event does not inherit stale metadata.

## Why

`reset()` already clears the decoder, text buffer, event ID, event name, data, and CRLF state, but it leaves `extra` untouched. If `reset()` is called after a parsed `meta:` line but before the event is dispatched, that stale metadata can leak into the next event.

This keeps `reset()` semantics consistent across all parser state without changing normal event parsing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resetting the event parser now clears pending event metadata, preventing stale metadata from appearing in subsequent events.

* **Tests**
  * Added coverage verifying that reset operations emit later events without previously stored metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->